### PR TITLE
fix: .gitignore to ignore generated files specifically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ models
 reports
 
 # Those files are generated at build time
-domain.yml
-config.yml
+/domain.yml
+/config.yml
 data/nlu.md


### PR DESCRIPTION
## Description
Changed .gitignore to ignore generated files more specifically (instead of globally by file name).
<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->

## Related JIRA issues
<!-- Pull requests should be related to open JIRA issues. -->
<!-- Please put all related JIRA issue IDs in square brackets here: -->
<!-- * [DIA-123] -->
<!-- * [SOL-456] -->

## Related changes
Merge #3 after this one.
<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * dialoguemd/{repository}#{pr-number}  -->

## Checklist

- [ ] PR title follows [Commit Convention](https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0) <!-- `feat(lang): add German language` -->
- [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error [DIA-000]` -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
- [ ] [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests) is opened for WIP changes <!-- If required. -->
- [ ] PR review requested from groups not individuals <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
- [ ] PR link is posted to the corresponding Slack channel <!-- This will quickly draw attention to your PR. -->


[DIA-123]: https://dialoguemd.atlassian.net/browse/DIA-123
[SOL-456]: https://dialoguemd.atlassian.net/browse/SOL-456