### PR TITLE
feat(dialogue): allow assessment after QA (#46)

### DIFF
--- a/action-server/actions/answers.py
+++ b/action-server/actions/answers.py
@@ -14,6 +14,8 @@ HTTP_OK = 200
 class QuestionAnsweringStatus(str, Enum):
     SUCCESS = "success"
     FAILURE = "failure"
+    NEED_ASSESSMENT = "need_assessment"
+    OUT_OF_DISTRIBUTION = "out_of_distribution"
 
 
 class QuestionAnsweringResponse(BaseModel):

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -8,18 +8,20 @@
   - utter_goodbye
 
 ## suspect - severe symptoms
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "severe"}
   - action_severe_symptoms_recommendations
 
 ## suspect - moderate symptoms
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - action_suspect_moderate_symptoms_recommendations
   - utter_ask_want_checkin
@@ -32,12 +34,20 @@
   - action_set_risk_level
   - utter_visit_package
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_another_question
 
 ## suspect - moderate symptoms no checkin
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - action_suspect_moderate_symptoms_recommendations
   - utter_ask_want_checkin
@@ -48,10 +58,11 @@
   - utter_ask_anything_else
 
 ## suspect - mild symptoms no checkin
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - action_suspect_mild_symptoms_exposure_recommendations
   - utter_ask_want_checkin
@@ -60,12 +71,22 @@
   - action_set_risk_level
   - utter_visit_package
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - utter_goodbye
 
 ## suspect - no symptoms contact
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * affirm{"contact": true}
@@ -82,10 +103,11 @@
   - utter_ask_anything_else
 
 ## suspect - no symptoms contact no checkin
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * affirm{"contact": true}
@@ -98,10 +120,11 @@
   - utter_ask_anything_else
 
 ## suspect - no symptoms no contact travel
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * deny{"contact": false}
@@ -118,12 +141,24 @@
   - action_set_risk_level
   - utter_visit_package
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
+* done
+  - utter_please_visit_again
+  - utter_goodbye
 
 ## suspect - no symptoms no contact travel no checkin
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * deny{"contact": false}
@@ -138,10 +173,11 @@
   - utter_ask_anything_else
 
 ## suspect - no symptoms no contact no travel
-* suspect
+* suspect OR get_assessment
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * deny{"contact": false}
@@ -157,6 +193,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "severe"}
   - utter_call_911
 
@@ -165,6 +202,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - utter_symptoms_worsen_emergency_assistance
   - utter_ask_want_checkin
@@ -178,6 +216,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - utter_symptoms_worsen_emergency_assistance
   - utter_ask_want_checkin
@@ -195,6 +234,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_symptoms_worsened
 * affirm
@@ -204,12 +244,27 @@
   - utter_acknowledge_remind_monitor_symptoms_temperature
   - utter_remind_possible_checkin
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_another_question
 
 ## tested positive - mild symptoms worse
 * tested_positive
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_symptoms_worsened
 * affirm
@@ -229,6 +284,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_symptoms_worsened
 * deny
@@ -243,6 +299,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_symptoms_worsened
 * deny
@@ -261,6 +318,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_no_symptoms
   - utter_ask_when_tested
@@ -270,12 +328,22 @@
   - utter_acknowledge_remind_monitor_symptoms_temperature
   - utter_remind_possible_checkin
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - utter_goodbye
 
 # tested positive - no symptoms tested less than 14 days
 * tested_positive
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_no_symptoms
   - utter_ask_when_tested
@@ -295,24 +363,13 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_no_symptoms
   - utter_ask_when_tested
 * more
   - utter_maybe_cured
   - utter_ask_anything_else
-
-## QA - failure - ENDS LIKE IF ASSESSMENT ALREADY DONE
-* ask_question
-  - utter_can_help_with_questions
-  - question_answering_form
-  - form{"name": "question_answering_form"}
-  - form{"name": null}
-  - slot{"question_answering_status": "failure"}
-  - utter_question_answering_error
-  - utter_goodbye
-
-## QA - success - ENDS LIKE IF ASSESSMENT ALREADY DONE
 * ask_question
   - utter_can_help_with_questions
   - question_answering_form
@@ -320,12 +377,23 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_another_question
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
+* done
+  - utter_please_visit_again
+  - utter_goodbye
 
 ## return for check-in - severe symptoms
 * checkin_return
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "severe"}
   - utter_call_911
 
@@ -334,6 +402,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - action_set_risk_level
   - utter_ask_symptoms_worsened
@@ -347,6 +416,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - action_set_risk_level
   - utter_ask_symptoms_worsened
@@ -361,12 +431,24 @@
   - utter_remind_possible_checkin
   - utter_visit_package
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
+* done
+  - utter_please_visit_again
+  - utter_goodbye
 
 ## return for check-in - moderate symptoms - no check-in
 * checkin_return
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
   - action_set_risk_level
   - utter_ask_symptoms_worsened
@@ -385,6 +467,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_want_checkin_acknowledge
 * affirm
@@ -401,6 +484,7 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
   - utter_ask_want_checkin_acknowledge
 * deny
@@ -409,12 +493,20 @@
   - utter_remind_possible_checkin
   - utter_visit_package
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_another_question
 
 ## return for check-in - no symptoms - first symptoms >= 14 days ago
 * checkin_return
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_no_symptoms
   - utter_ask_when_first_symptoms
@@ -427,9 +519,81 @@
   - assessment_form
   - form{"name": "assessment_form"}
   - form{"name": null}
+  - slot{"self_assess_done": true}
   - slot{"symptoms": "none"}
   - utter_no_symptoms
   - utter_ask_when_first_symptoms
 * less
   - utter_self_isolate_symptom_free
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - utter_goodbye
+
+## QA - failure - no assessment after
+* greet
+  - utter_greet
+  - utter_ask_how_may_i_help
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_ask_assess_after_error
+* deny
+  - utter_try_again_later
+  - utter_goodbye
+
+## QA - success
+* greet
+  - utter_greet
+  - utter_ask_how_may_i_help
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_what_next_after_answer
+
+## QA - success - another question
+* greet
+  - utter_greet
+  - utter_ask_how_may_i_help
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_what_next_after_answer
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_what_next_after_answer
+
+## QA - need_assessment - no assessment after
+* greet
+  - utter_greet
+  - utter_ask_how_may_i_help
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment
+  - utter_ask_assess_to_answer
+* done
+  - utter_please_visit_again
+  - utter_goodbye

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -14,6 +14,7 @@ intents:
   - help_pre_existing_conditions:
       triggers: action_explain_pre_existing_conditions
   - done
+  - get_assessment
 
 entities:
   - province
@@ -98,6 +99,9 @@ slots:
     values:
       - success
       - failure
+
+  self_assess_done:
+    type: bool
 
 session_config:
   session_expiration_time: 60 # value in minutes

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -333,11 +333,11 @@ responses:
   utter_question_answering_error:
     - text: "I’m sorry, I’m not able to get an answer to your question at this time."
 
-  utter_ask_assessment_after_error:
+  utter_ask_assess_after_error:
     - text: "Do you want me to help you assess your symptoms?"
       buttons:
         - title: Yes
-          payload: "/affirm"
+          payload: "/get_assessment"
         - title: No
           payload: "/deny"
 
@@ -351,12 +351,15 @@ responses:
     - text: "It seems like you need help with your symptoms."
 
   utter_ask_assess_to_answer:
-    - text: "Do you want me to assess/reassess your symptoms?"
+    - text: "Do you want me to assess your symptoms?"
       buttons:
         - title: Yes
-          payload: "/affirm"
+          payload: "/get_assessment"
         - title: No
           payload: "/deny"
+
+  utter_need_assessment_already_done:
+    - text: It seems that to answer your question, I would need to assess your symptoms. However, we have already done that.
 
   utter_please_visit_again:
     - text: "Got it. Please visit us again if you need help or have additional questions."
@@ -367,12 +370,12 @@ responses:
         - title: "Ask another question"
           payload: "/ask_question"
         - title: "Get self-assessment"
-          payload: "/get_assessment"
+          payload: "/suspect"
         - title: "I'm done"
           payload: "/done"
 
   utter_ask_another_question:
-    - text: "Do you have another question?"
+    - text: "Would you like to ask another question?"
       buttons:
         - title: Yes
           payload: "/ask_question"

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -330,11 +330,11 @@ responses:
   utter_question_answering_error:
     - text: "Je suis désolée, il n’est pas possible d’obtenir de réponse à vos questions en ce moment."
 
-  utter_ask_assessment_after_error:
+  utter_ask_assess_after_error:
     - text: "Voudriez-vous que je vous aide à évaluer vos symptômes?"
       buttons:
         - title: Oui
-          payload: "/affirm"
+          payload: "/get_assessment"
         - title: Non
           payload: "/deny"
 
@@ -351,12 +351,15 @@ responses:
     - text: "Il semble que vous ayez besoin d’aide pour évaluer vos symptômes."
 
   utter_ask_assess_to_answer:
-    - text: "Voulez-vous que j’évalue/je réévalue vos symptômes?"
+    - text: "Voulez-vous que j’évalue vos symptômes?"
       buttons:
         - title: Oui
-          payload: "/affirm"
+          payload: "/get_assessment"
         - title: Non
           payload: "/deny"
+
+  utter_need_assessment_already_done:
+    - text: "Il semble que pour répondre à votre question, j’aurais besoin d’évaluer vos symptômes. Or, c’est ce que nous venons de faire."
 
   utter_please_visit_again:
     - text: "Très bien. N’hésitez pas à revenir si vous avez besoin d’aide ou si vous avez d’autres questions."
@@ -367,12 +370,12 @@ responses:
         - title: "Poser une autre question"
           payload: "/ask_question"
         - title: "Évaluation de mes symptômes"
-          payload: "/get_assessment"
+          payload: "/suspect"
         - title: "J'ai terminé"
           payload: "/done"
 
   utter_ask_another_question:
-    - text: "Avez-vous d'autres questions?"
+    - text: "Aimeriez-vous poser une autre question?"
       buttons:
         - title: Oui
           payload: "/ask_question"


### PR DESCRIPTION
## Description
Added "self_asssess_done" slot so that ML could distinguish assessment has been done before whatever the number of loops inside QAs.
Added surface support for "need_assessment" and "out_of_distribution" answers from QA service to add these paths to dialogue

Assessment after QA does not change, so the stories are not "complete", we trust that the good intent triggered is enough to start the assessment with memoization. Stories had to be added for QA after assessment and for QA after QA because a prompt disappears when we loop. 

## Related issues
#46 

## Checklist

- [ X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
