### PR TITLE
feat: support metadata entity used in greet intent (#63)

### DIFF
--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -1,5 +1,5 @@
 ## greet
-* greet
+* greet{"metadata":{}}
   - utter_greet
   - utter_ask_how_may_i_help
 
@@ -537,7 +537,7 @@
   - utter_goodbye
 
 ## QA - failure - no assessment after
-* greet
+* greet{"metadata":{}}
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
@@ -553,7 +553,7 @@
   - utter_goodbye
 
 ## QA - success
-* greet
+* greet{"metadata":{}}
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
@@ -565,7 +565,7 @@
   - utter_ask_what_next_after_answer
 
 ## QA - success - another question
-* greet
+* greet{"metadata":{}}
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
@@ -583,7 +583,7 @@
   - utter_ask_what_next_after_answer
 
 ## QA - need_assessment - no assessment after
-* greet
+* greet{"metadata":{}}
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
@@ -599,6 +599,6 @@
   - utter_goodbye
 
 ## daily check-in
-* daily_checkin{"metadata": "data"}
+* daily_checkin{"metadata":{}}
   - utter_greet_daily_checkin
   - utter_ask_how_do_you_feel

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -43,6 +43,9 @@ forms:
   - question_answering_form
 
 slots:
+  metadata:
+    type: unfeaturized
+
   language:
     type: unfeaturized
     initial_value: *language


### PR DESCRIPTION
## Description
Frontend will very soon send metadata (with timezone) as part of the /greet (initial payload).

The timezone will be used to avoid sending notification in the middle of the night :)

## Related issues
#63 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
