### PR TITLE
feat(dialogue): update generic assessment to v8

### DIFF
--- a/action-server/actions/action_offer_daily_checkin.py
+++ b/action-server/actions/action_offer_daily_checkin.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, List, Text
+
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+
+class ActionOfferDailyCheckin(Action):
+    def name(self) -> Text:
+        return "action_offer_daily_checkin"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict[Text, Any]]:
+
+        dispatcher.utter_message(template="utter_offer_checkin")
+        dispatcher.utter_message(template="utter_explain_checkin_contact")
+        dispatcher.utter_message(template="utter_explain_checkin_assessment")
+        dispatcher.utter_message(template="utter_ask_want_checkin")
+
+        return []

--- a/action-server/actions/action_suspect_mild_symptoms_exposure_recommendations.py
+++ b/action-server/actions/action_suspect_mild_symptoms_exposure_recommendations.py
@@ -15,8 +15,6 @@ class ActionSuspectMildSymptomsExposureRecommendations(Action):
         domain: Dict[Text, Any],
     ) -> List[Dict[Text, Any]]:
 
-        dispatcher.utter_message(template="utter_self_isolate")
-        dispatcher.utter_message(template="utter_home_assistance")
         dispatcher.utter_message(template="utter_monitor_symptoms_changes")
 
         return []

--- a/action-server/actions/action_suspect_moderate_symptoms_recommendations.py
+++ b/action-server/actions/action_suspect_moderate_symptoms_recommendations.py
@@ -15,8 +15,6 @@ class ActionSuspectModerateSymptomsRecommendations(Action):
         domain: Dict[Text, Any],
     ) -> List[Dict[Text, Any]]:
 
-        dispatcher.utter_message(template="utter_self_isolate")
-        dispatcher.utter_message(template="utter_home_assistance")
         dispatcher.utter_message(template="utter_symptoms_worsen_emergency")
         dispatcher.utter_message(template="utter_monitor_symptoms_assistance")
 

--- a/action-server/actions/action_suspect_no_symptoms_recommendations.py
+++ b/action-server/actions/action_suspect_no_symptoms_recommendations.py
@@ -18,5 +18,6 @@ class ActionSuspectNoSymptomsRecommendations(Action):
         dispatcher.utter_message(template="utter_probably_not_covid")
         dispatcher.utter_message(template="utter_social_distancing")
         dispatcher.utter_message(template="utter_checkin_if_developments")
+        dispatcher.utter_message(template="utter_link_if_anxious")
 
         return []

--- a/action-server/actions/assessment_form.py
+++ b/action-server/actions/assessment_form.py
@@ -26,6 +26,7 @@ class AssessmentForm(FormAction):
 
         return "assessment_form"
 
+    ## Order corresponds to v8 entry and mild flows updated - may not match returning and tested_positive flows
     @staticmethod
     def required_slots(tracker: Tracker) -> List[Text]:
         if tracker.get_slot(SEVERE_SYMPTOMS_SLOT):
@@ -34,18 +35,18 @@ class AssessmentForm(FormAction):
             return [
                 ASSESSMENT_TYPE_SLOT,
                 SEVERE_SYMPTOMS_SLOT,
-                HAS_FEVER_SLOT,
                 PROVINCE_SLOT,
                 AGE_OVER_65_SLOT,
+                HAS_FEVER_SLOT,
                 MODERATE_SYMPTOMS_SLOT,
             ]
 
         return [
             ASSESSMENT_TYPE_SLOT,
             SEVERE_SYMPTOMS_SLOT,
-            HAS_FEVER_SLOT,
             PROVINCE_SLOT,
             AGE_OVER_65_SLOT,
+            HAS_FEVER_SLOT,
             MODERATE_SYMPTOMS_SLOT,
             HAS_COUGH_SLOT,
         ]
@@ -89,8 +90,6 @@ class AssessmentForm(FormAction):
     ) -> Dict[Text, Any]:
 
         if value == GET_ASSESSMENT:
-            dispatcher.utter_message(template="utter_ok")
-
             return {ASSESSMENT_TYPE_SLOT: SUSPECT}
 
         if value == CHECKIN_RETURN:

--- a/action-server/actions/home_assistance_form.py
+++ b/action-server/actions/home_assistance_form.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List, Text, Union
+
+from rasa_sdk import Tracker
+from rasa_sdk.executor import CollectingDispatcher
+from rasa_sdk.forms import FormAction
+
+PROVINCES_WITH_211 = ["bc", "ab", "sk", "mb", "on", "qc", "ns"]
+
+PROVINCE_SLOT = "province"
+HAS_ASSISTANCE_SLOT = "has_assistance"
+
+
+def _has_211(tracker: Tracker) -> bool:
+    province = tracker.get_slot(PROVINCE_SLOT)
+    return province in PROVINCES_WITH_211
+
+
+class HomeAssistanceForm(FormAction):
+    def name(self) -> Text:
+
+        return "home_assistance_form"
+
+    @staticmethod
+    def required_slots(tracker: Tracker) -> List[Text]:
+        if _has_211(tracker):
+            return [HAS_ASSISTANCE_SLOT]
+
+        return []
+
+    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
+        return {
+            HAS_ASSISTANCE_SLOT: [
+                self.from_intent(intent="affirm", value=True),
+                self.from_intent(intent="deny", value=False),
+            ],
+        }
+
+    def submit(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict]:
+
+        if _has_211(tracker) and not tracker.get_slot(HAS_ASSISTANCE_SLOT):
+            dispatcher.utter_message(template="utter_check_delivery_services")
+            dispatcher.utter_message(template="utter_may_call_211")
+            dispatcher.utter_message(template="utter_explain_211")
+        else:
+            dispatcher.utter_message(template="utter_remind_delivery_services")
+
+        dispatcher.utter_message(template="utter_remind_pharmacist_services")
+
+        return []

--- a/action-server/actions/self_isolation_form.py
+++ b/action-server/actions/self_isolation_form.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Text, Union
+
+from rasa_sdk import Tracker
+from rasa_sdk.events import EventType
+from rasa_sdk.executor import CollectingDispatcher
+from rasa_sdk.forms import FormAction
+
+LIVES_ALONE_SLOT = "lives_alone"
+
+
+class SelfIsolationForm(FormAction):
+    def name(self) -> Text:
+
+        return "self_isolation_form"
+
+    ## override to play initial message
+    async def _activate_if_required(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: Dict[Text, Any],
+    ) -> List[EventType]:
+        if tracker.active_form.get("name") != "self_isolation_form":
+            dispatcher.utter_message(template="utter_symptoms_self_isolate")
+
+        return await super()._activate_if_required(dispatcher, tracker, domain)
+
+    @staticmethod
+    def required_slots(tracker: Tracker) -> List[Text]:
+        return [LIVES_ALONE_SLOT]
+
+    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
+        return {
+            LIVES_ALONE_SLOT: [
+                self.from_intent(intent="affirm", value=True),
+                self.from_intent(intent="deny", value=False),
+            ],
+        }
+
+    def submit(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict]:
+
+        if tracker.get_slot(LIVES_ALONE_SLOT):
+            dispatcher.utter_message(
+                template="utter_dont_leave_home_unless_appointment"
+            )
+        else:
+            dispatcher.utter_message(template="utter_stay_separate_room")
+            dispatcher.utter_message(template="utter_distance_clean_surfaces")
+            dispatcher.utter_message(template="utter_wear_mask_same_room")
+
+        dispatcher.utter_message(template="utter_self_isolation_link")
+
+        return []

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -23,8 +23,14 @@
   - form{"name": null}
   - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_moderate_symptoms_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * affirm
   - utter_daily_checkin_enroll
   - daily_ci_enroll_form
@@ -49,8 +55,14 @@
   - form{"name": null}
   - slot{"self_assess_done": true}
   - slot{"symptoms": "moderate"}
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_moderate_symptoms_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * deny
   - action_suspect_moderate_symptoms_final_recommendations
   - action_set_risk_level
@@ -64,8 +76,14 @@
   - form{"name": null}
   - slot{"self_assess_done": true}
   - slot{"symptoms": "mild"}
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_mild_symptoms_exposure_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * deny
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - action_set_risk_level
@@ -90,8 +108,14 @@
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * affirm{"contact": true}
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_mild_symptoms_exposure_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * affirm
   - utter_daily_checkin_enroll
   - daily_ci_enroll_form
@@ -111,8 +135,14 @@
   - slot{"symptoms": "none"}
   - utter_ask_contact
 * affirm{"contact": true}
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_mild_symptoms_exposure_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * deny
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - action_set_risk_level
@@ -130,8 +160,14 @@
 * deny{"contact": false}
   - utter_ask_travel
 * affirm
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_mild_symptoms_exposure_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * affirm
   - utter_daily_checkin_enroll
   - daily_ci_enroll_form
@@ -164,8 +200,14 @@
 * deny{"contact": false}
   - utter_ask_travel
 * affirm
+  - self_isolation_form
+  - form{"name": "self_isolation_form"}
+  - form{"name": null}
+  - home_assistance_form
+  - form{"name": "home_assistance_form"}
+  - form{"name": null}
   - action_suspect_mild_symptoms_exposure_recommendations
-  - utter_ask_want_checkin
+  - action_offer_daily_checkin
 * deny
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - action_set_risk_level

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -40,11 +40,14 @@ actions:
   - action_tested_positive_maybe_cured_final_recommendations
   - action_tested_positive_not_cured_final_recommendations
   - action_severe_symptoms_recommendations
+  - action_offer_daily_checkin
 
 forms:
   - assessment_form
   - daily_ci_enroll_form
   - question_answering_form
+  - self_isolation_form
+  - home_assistance_form
 
 slots:
   metadata:
@@ -118,6 +121,12 @@ slots:
 
   self_assess_done:
     type: bool
+
+  lives_alone:
+    type: unfeaturized
+
+  has_assistance:
+    type: unfeaturized
 
 session_config:
   session_expiration_time: 60 # value in minutes

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -7,15 +7,14 @@ responses:
       buttons:
         - title: "I am returning for my check-in on my Covid-19"
           payload: "/checkin_return"
+        - title: "I want to take the Covid-19 self-assessment"
+          payload: "/get_assessment"
         - title: "I suspect I have Covid-19"
           payload: "/suspect"
         - title: "I have been tested positive for Covid-19"
           payload: "/tested_positive"
         - title: "I have a question about Covid-19"
           payload: "/ask_question"
-
-  utter_tested_positive:
-    - text: (tested positive flow)
 
   utter_ask_severe_symptoms:
     - text: "First, are you experiencing any of the following symptoms:\n- Severe difficulty breathing\n- Severe chest pain\n- Having a hard time waking up\n- Feeling confused\n- Losing consciousness"
@@ -52,6 +51,15 @@ responses:
 
   utter_monitor_symptoms_assistance:
     - text: "Please monitor your symptoms. If you need assistance, you should:\n- Contact your family doctor if possible, or\n- Call 811 for assistance"
+
+  utter_offer_checkin:
+    - text: "If you'd like, you can enroll in our daily check-in."
+
+  utter_explain_checkin_contact:
+    - text: "If you do, I will contact you everyday to see how you’re doing, monitor your symptoms, evaluate your general health, and provide recommendations to help take care of yourself and relieve your symptoms."
+
+  utter_explain_checkin_assessment:
+    - text: "The daily check-in offers you an updated assessment of your condition everyday, so that you receive the most relevant guidance and recommendations for your condition."
 
   utter_ask_want_checkin:
     - text: "Would you like me to check-in with you daily to help monitor your symptoms?"
@@ -113,6 +121,9 @@ responses:
 
   utter_checkin_if_developments:
     - text: "If you develop any symptoms in the future, or if you get in contact with someone who has the Covid-19, please check-in with me for an assessment and recommendations."
+
+  utter_link_if_anxious:
+    - text: If you feel anxious about Covid-19 or your own wellbeing, please visit [Wellness Together Canada](https://ca.portal.gs/)
 
   # province age form
   utter_ask_province:
@@ -382,7 +393,60 @@ responses:
         - title: "No I'm done"
           payload: "/done"
 
-## Daily check-in
+  ## action self-isolation
+
+  utter_symptoms_self_isolate:
+    - text: "Since you have symptoms, you need to self-isolate for at least 14 days. It is extremely important that you follow this directive."
+
+  utter_ask_lives_alone:
+    - text: "Are you the only person in your household?"
+      buttons:
+        - title: Yes
+          payload: "/affirm"
+        - title: No
+          payload: "/deny"
+
+  utter_dont_leave_home_unless_appointment:
+    - text: "In this case, I recommend that you don’t leave your home unless you have a doctor’s appointment, or if you need to go to the hospital."
+
+  utter_stay_separate_room:
+    - text: "In this case, you should stay in a separate room and use a different bathroom from others, if possible."
+
+  utter_distance_clean_surfaces:
+    - text: "If it’s not possible, ensure you stay at least 2 meters, or six feet, away from others in your home at all times, wash your hands often, and make sure every surface and object are cleaned after use."
+
+  utter_wear_mask_same_room:
+    - text: "You should also wear a mask every time you are in the same room as others."
+
+  utter_self_isolation_link:
+    - text: "For more information about self-isolation, and to learn what you can do to protect others, visit [canada.ca](https://www.canada.ca/en/public-health/services/publications/diseases-conditions/covid-19-how-to-isolate-at-home.html)"
+
+  ## action home-assistance
+
+  utter_ask_has_assistance:
+    - text: "Do you have help from someone to run errands for you (a parent, spouse, a friend or neighbour), like going to the grocery store or get medications?"
+      buttons:
+        - title: Yes
+          payload: "/affirm"
+        - title: No
+          payload: "/deny"
+
+  utter_remind_delivery_services:
+    - text: "Don’t forget that most pharmacies and many grocery stores offer delivery services. Check with your local pharmacy or grocery store if they deliver."
+
+  utter_check_delivery_services:
+    - text: "Most pharmacies and many grocery stores offer delivery services. You can check with your local pharmacy or grocery store if they offer this service."
+
+  utter_may_call_211:
+    - text: "If that’s not possible for you, you may call 211 or visit 211.ca for assistance."
+
+  utter_explain_211:
+    - text: "The 211 service can direct you to a variety of local resources for assistance with food, health, or community services."
+
+  utter_remind_pharmacist_services:
+    - text: "Your pharmacist can also provide recommendations and advice on how to relieve your symptoms and which over-the-counter medications you can safely take."
+
+  ## Daily check-in
 
   utter_greet_daily_checkin:
     - text: Hello Linda, this is Chloe, and I'm checking in to see how you're doing today.

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -2,6 +2,7 @@ responses:
   utter_greet:
     - text: "Bonjour, je m'appelle Chloé, votre assistante médicale. Je peux vous aider à évaluer vos symptômes et vous donner de l'information en lien avec la Covid-19."
 
+  ## to be translated - not really but missing one option that was not translated
   utter_ask_how_may_i_help:
     - text: Que puis-je faire pour vous aujourd'hui?
       buttons:
@@ -13,9 +14,6 @@ responses:
           payload: "/tested_positive"
         - title: "J'ai des questions à propos de la Covid-19"
           payload: "/ask_question"
-
-  utter_tested_positive:
-    - text: (tested positive flow)
 
   utter_ask_severe_symptoms:
     - text: "Premièrement, avez-vous un ou plusieurs des symptômes suivants:\n- Difficultés respiratoires graves\n- De fortes douleurs à la poitrine\n- Avoir beaucoup de mal à se réveiller\n- Être confus\n- Perte de conscience"
@@ -52,6 +50,16 @@ responses:
 
   utter_monitor_symptoms_assistance:
     - text: "Assurez-vous de suivre l'évolution de vos symptômes. Si vous avez besoin d'assistance, vous devriez: \n- Communiquer avec votre médecin de famille, si c'est possible, ou \n- Appeler le 811"
+
+  ## next 3 to be translated
+  utter_offer_checkin:
+    - text: "If you'd like, you can enroll in our daily check-in."
+
+  utter_explain_checkin_contact:
+    - text: "If you do, I will contact you everyday to see how you’re doing, monitor your symptoms, evaluate your general health, and provide recommendations to help take care of yourself and relieve your symptoms."
+
+  utter_explain_checkin_assessment:
+    - text: "The daily check-in offers you an updated assessment of your condition everyday, so that you receive the most relevant guidance and recommendations for your condition."
 
   utter_ask_want_checkin:
     - text: "Aimeriez-vous que je communique avec vous quotidiennement pour vous aider à suivre l'évolution de vos symptômes?"
@@ -113,6 +121,10 @@ responses:
 
   utter_checkin_if_developments:
     - text: "Si vous développez des symptômes, ou si vous entrez en contact avec une personne atteinte de la Covid-19, veuillez communiquer avec moi pour obtenir une évaluation et des recommandations."
+
+  ## to be translated
+  utter_link_if_anxious:
+    - text: If you feel anxious about Covid-19 or your own wellbeing, please visit [Wellness Together Canada](https://ca.portal.gs/)
 
   # province age form
   utter_ask_province:
@@ -382,7 +394,60 @@ responses:
         - title: "Non j'ai terminé"
           payload: "/done"
 
-## Daily check-in (to be translated)
+  ## action self-isolation (to be translated)
+
+  utter_symptoms_self_isolate:
+    - text: "Since you have symptoms, you need to self-isolate for at least 14 days. It is extremely important that you follow this directive."
+
+  utter_ask_lives_alone:
+    - text: "Are you the only person in your household?"
+      buttons:
+        - title: Yes
+          payload: "/affirm"
+        - title: No
+          payload: "/deny"
+
+  utter_dont_leave_home_unless_appointment:
+    - text: "In this case, I recommend that you don’t leave your home unless you have a doctor’s appointment, or if you need to go to the hospital."
+
+  utter_stay_separate_room:
+    - text: "In this case, you should stay in a separate room and use a different bathroom from others, if possible."
+
+  utter_distance_clean_surfaces:
+    - text: "If it’s not possible, ensure you stay at least 2 meters, or six feet, away from others in your home at all times, wash your hands often, and make sure every surface and object are cleaned after use."
+
+  utter_wear_mask_same_room:
+    - text: "You should also wear a mask every time you are in the same room as others."
+
+  utter_self_isolation_link:
+    - text: "For more information about self-isolation, and to learn what you can do to protect others, visit [canada.ca](https://www.canada.ca/en/public-health/services/publications/diseases-conditions/covid-19-how-to-isolate-at-home.html)"
+
+  ## action home-assistance (to be translated)
+
+  utter_ask_has_assistance:
+    - text: "Do you have help from someone to run errands for you (a parent, spouse, a friend or neighbour), like going to the grocery store or get medications?"
+      buttons:
+        - title: Yes
+          payload: "/affirm"
+        - title: No
+          payload: "/deny"
+
+  utter_remind_delivery_services:
+    - text: "Don’t forget that most pharmacies and many grocery stores offer delivery services. Check with your local pharmacy or grocery store if they deliver."
+
+  utter_check_delivery_services:
+    - text: "Most pharmacies and many grocery stores offer delivery services. You can check with your local pharmacy or grocery store if they offer this service."
+
+  utter_may_call_211:
+    - text: "If that’s not possible for you, you may call 211 or visit 211.ca for assistance."
+
+  utter_explain_211:
+    - text: "The 211 service can direct you to a variety of local resources for assistance with food, health, or community services."
+
+  utter_remind_pharmacist_services:
+    - text: "Your pharmacist can also provide recommendations and advice on how to relieve your symptoms and which over-the-counter medications you can safely take."
+
+  ## Daily check-in (to be translated)
 
   utter_greet_daily_checkin:
     - text: Hello Linda, this is Chloe, and I'm checking in to see how you're doing today.


### PR DESCRIPTION
## Description
These changes were made to the "suspect"/generic assessment flow:
 - added want_assessment option in menu which leads to same flow as suspect (english-only)
- switched fever and province-age questions (this change affects tested-positive and returning flows but they are still logic so I'll wait adjustments in the design to adapt it if necessary)
- added messages explaining check-in and wrapped in an action
- replaced self-isolation and home assistance messages in recommendations by two little forms)
- added one message to recommendations for people with no risk factors

## Checklist

- [ X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
