### PR TITLE
feat: send reminder SMS upon reception of an external event (#60)

### DIFF
--- a/action-server/actions/action_send_daily_checkin_reminder.py
+++ b/action-server/actions/action_send_daily_checkin_reminder.py
@@ -1,0 +1,93 @@
+import logging
+import os
+import urllib.parse
+from typing import Any, Dict, List, Text
+
+from hashids import Hashids
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+from db.base import session_factory
+from db.reminder import Reminder
+
+from .lib.exceptions import InvalidExternalEventException, ReminderNotFoundException
+
+logger = logging.getLogger(__name__)
+
+METADATA_ENTITY_NAME = "metadata"
+REMINDER_ID_PROPERTY_NAME = "reminder_id"
+
+CHECKIN_BASE_URL_ENV_KEY = "DAILY_CHECKIN_BASE_URL"
+HASHIDS_SALT_ENV_KEY = "REMINDER_ID_HASHIDS_SALT"
+HASHIDS_MIN_LENGTH_ENV_KEY = "REMINDER_ID_HASHIDS_MIN_LENGTH"
+
+
+def _query_reminder(reminder_id):
+    session = session_factory()
+    try:
+        reminder = session.query(Reminder).get(reminder_id)
+        if reminder is None:
+            raise ReminderNotFoundException(
+                f"Reminder with id '{reminder_id}' does not exist."
+            )
+        return reminder
+    finally:
+        session.close()
+
+
+def _get_env(name):
+    value = os.environ.get(name)
+    if value is None:
+        raise Exception(f"Environment variable '{name}' is not set.")
+    return value
+
+
+class ActionSendDailyCheckInReminder(Action):
+    def __init__(self):
+        salt = _get_env(HASHIDS_SALT_ENV_KEY)
+        min_length = _get_env(HASHIDS_MIN_LENGTH_ENV_KEY)
+        base_url = _get_env(CHECKIN_BASE_URL_ENV_KEY)
+
+        # Always appending '/', `urljoin` will take care of removing superfluous slash.
+        self.base_url = base_url + "/"
+        self.hashids = Hashids(salt, min_length=min_length)
+
+    def name(self) -> Text:
+        return "action_send_daily_checkin_reminder"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict[Text, Any]]:
+        metadata = next(tracker.get_latest_entity_values(METADATA_ENTITY_NAME))
+        hashed_id = metadata[REMINDER_ID_PROPERTY_NAME]
+        reminder_id = self.hashids.decode(hashed_id)[0]
+
+        conversation_id = tracker.sender_id
+
+        reminder = _query_reminder(reminder_id)
+        first_name = reminder.first_name
+        phone_number = reminder.phone_number
+
+        if conversation_id != phone_number:
+            raise InvalidExternalEventException(
+                f"Phone number does not match sender_id: reminder_id={reminder_id} sender_id={conversation_id} phone_number={phone_number}"
+            )
+
+        checkin_url = urllib.parse.urljoin(self.base_url, hashed_id)
+
+        logger.debug(
+            "Sending daily check-in reminder: checkin_url=%s first_name=%s.",
+            checkin_url,
+            first_name,
+        )
+
+        dispatcher.utter_message(
+            template="utter_checkin_reminder",
+            first_name=first_name,
+            check_in_url=checkin_url,
+        )
+
+        return []

--- a/action-server/actions/lib/exceptions.py
+++ b/action-server/actions/lib/exceptions.py
@@ -1,0 +1,6 @@
+class ReminderNotFoundException(Exception):
+    pass
+
+
+class InvalidExternalEventException(Exception):
+    pass

--- a/action-server/db/reminder.py
+++ b/action-server/db/reminder.py
@@ -26,3 +26,11 @@ class Reminder(Base):
     def __init__(self, timezone, attributes):
         self.timezone = timezone
         self.attributes = attributes
+
+    @property
+    def first_name(self):
+        return self.attributes["first_name"]
+
+    @property
+    def phone_number(self):
+        return self.attributes["phone_number"]

--- a/action-server/db/reminder.py
+++ b/action-server/db/reminder.py
@@ -34,3 +34,7 @@ class Reminder(Base):
     @property
     def phone_number(self):
         return self.attributes["phone_number"]
+
+    @property
+    def language(self):
+        return self.attributes["language"]

--- a/action-server/mypy.ini
+++ b/action-server/mypy.ini
@@ -2,3 +2,6 @@
 
 [mypy-rasa_sdk.*]
 ignore_missing_imports = True
+
+[mypy-hashids.*]
+ignore_missing_imports = True

--- a/action-server/poetry.lock
+++ b/action-server/poetry.lock
@@ -240,6 +240,14 @@ hyperframe = ">=5.2.0,<6"
 
 [[package]]
 category = "main"
+description = "Python implementation of hashids (http://www.hashids.org).Compatible with python 2.6-3."
+name = "hashids"
+optional = false
+python-versions = "*"
+version = "1.2.0"
+
+[[package]]
+category = "main"
 description = "Pure-Python HPACK header compression"
 name = "hpack"
 optional = false
@@ -966,7 +974,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "e473b3167ae07a1ac478dec72861d9b888f1d8319070d5f11b63b198b558bd57"
+content-hash = "a0c12750d944163b7a037690fc167c609e6f3165fec47f923c2c8f7dd1f6bff2"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1090,6 +1098,9 @@ h11 = [
 h2 = [
     {file = "h2-3.2.0-py2.py3-none-any.whl", hash = "sha256:61e0f6601fa709f35cdb730863b4e5ec7ad449792add80d1410d4174ed139af5"},
     {file = "h2-3.2.0.tar.gz", hash = "sha256:875f41ebd6f2c44781259005b157faed1a5031df3ae5aa7bcb4628a6c0782f14"},
+]
+hashids = [
+    {file = "hashids-1.2.0.tar.gz", hash = "sha256:6539b892a426e75747a9c0ad69409e9566f9c21b79310fc3424b5b6726f28da6"},
 ]
 hpack = [
     {file = "hpack-3.0.0-py2.py3-none-any.whl", hash = "sha256:0edd79eda27a53ba5be2dfabf3b15780928a0dff6eb0c60a3d6767720e970c89"},

--- a/action-server/pyproject.toml
+++ b/action-server/pyproject.toml
@@ -16,6 +16,7 @@ structlog = "^20.1.0"
 pytz = "^2020.1"
 sqlalchemy = "~1.3.3"
 sqlalchemy-stubs = "^0.3"
+hashids = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.3.4"

--- a/action-server/tests/test_action_send_daily_checkin_reminder.py
+++ b/action-server/tests/test_action_send_daily_checkin_reminder.py
@@ -11,20 +11,27 @@ from actions.lib.exceptions import (
     ReminderNotFoundException,
 )
 
-CHECKIN_BASE_URL = "http://test.com/ci/"
+CHECKIN_URL_PATTERN = "http://test.com/?lng={language}#rasa/ci/{reminder_id}"
 HASHIDS_SALT = "abcd1234"
 HASHIDS_MIN_LENGTH = 4
 hashids = Hashids(HASHIDS_SALT, min_length=HASHIDS_MIN_LENGTH)
 
 DEFAULT_PHONE_NUMBER = "91112223333"
 DEFAULT_FIRST_NAME = "George"
+DEFAULT_LANGUAGE = "fr"
 DEFAULT_REMINDER_ID = 1
 DEFAULT_REMINDER_ID_HASH = hashids.encode(1)
 
 ENV = {
     "REMINDER_ID_HASHIDS_SALT": HASHIDS_SALT,
     "REMINDER_ID_HASHIDS_MIN_LENGTH": str(HASHIDS_MIN_LENGTH),
-    "DAILY_CHECKIN_BASE_URL": CHECKIN_BASE_URL,
+    "DAILY_CHECKIN_URL_PATTERN": CHECKIN_URL_PATTERN,
+}
+
+INVALID_PATTERN_ENV = {
+    "REMINDER_ID_HASHIDS_SALT": HASHIDS_SALT,
+    "REMINDER_ID_HASHIDS_MIN_LENGTH": str(HASHIDS_MIN_LENGTH),
+    "DAILY_CHECKIN_URL_PATTERN": "http://test.com/?lng={language}#rasa/ci/{rem}",
 }
 
 
@@ -49,6 +56,7 @@ def _mock_reminder(mock_session_factory, phone_number):
     )
     reminder_mock.first_name = DEFAULT_FIRST_NAME
     reminder_mock.phone_number = phone_number
+    reminder_mock.language = DEFAULT_LANGUAGE
 
 
 class TestActionSendDailyCheckinReminder(TestCase):
@@ -61,6 +69,11 @@ class TestActionSendDailyCheckinReminder(TestCase):
 
     def test_missing_environment_variables(self):
         with self.assertRaises(expected_exception=Exception):
+            ActionSendDailyCheckInReminder()
+
+    @patch.dict("os.environ", INVALID_PATTERN_ENV)
+    def test_invalid_url_pattern(self):
+        with self.assertRaises(expected_exception=KeyError):
             ActionSendDailyCheckInReminder()
 
     @patch.dict("os.environ", ENV)
@@ -79,7 +92,10 @@ class TestActionSendDailyCheckinReminder(TestCase):
         self.assertEqual(message["template"], "utter_checkin_reminder")
         self.assertEqual(message["first_name"], DEFAULT_FIRST_NAME)
         self.assertEqual(
-            message["check_in_url"], CHECKIN_BASE_URL + DEFAULT_REMINDER_ID_HASH,
+            message["check_in_url"],
+            CHECKIN_URL_PATTERN.format(
+                language=DEFAULT_LANGUAGE, reminder_id=DEFAULT_REMINDER_ID_HASH
+            ),
         )
 
     @patch.dict("os.environ", ENV)

--- a/action-server/tests/test_action_send_daily_checkin_reminder.py
+++ b/action-server/tests/test_action_send_daily_checkin_reminder.py
@@ -1,0 +1,105 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from hashids import Hashids
+from rasa_sdk import Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+from actions.action_send_daily_checkin_reminder import ActionSendDailyCheckInReminder
+from actions.lib.exceptions import (
+    InvalidExternalEventException,
+    ReminderNotFoundException,
+)
+
+CHECKIN_BASE_URL = "http://test.com/ci/"
+HASHIDS_SALT = "abcd1234"
+HASHIDS_MIN_LENGTH = 4
+hashids = Hashids(HASHIDS_SALT, min_length=HASHIDS_MIN_LENGTH)
+
+DEFAULT_PHONE_NUMBER = "91112223333"
+DEFAULT_FIRST_NAME = "George"
+DEFAULT_REMINDER_ID = 1
+DEFAULT_REMINDER_ID_HASH = hashids.encode(1)
+
+ENV = {
+    "REMINDER_ID_HASHIDS_SALT": HASHIDS_SALT,
+    "REMINDER_ID_HASHIDS_MIN_LENGTH": str(HASHIDS_MIN_LENGTH),
+    "DAILY_CHECKIN_BASE_URL": CHECKIN_BASE_URL,
+}
+
+
+def _create_tracker(
+    sender_id=DEFAULT_PHONE_NUMBER, reminder_id=DEFAULT_REMINDER_ID_HASH
+) -> Tracker:
+    return Tracker(
+        sender_id,
+        {},
+        {"entities": [{"entity": "metadata", "value": {"reminder_id": reminder_id}}]},
+        [],
+        False,
+        None,
+        {},
+        "action_listen",
+    )
+
+
+def _mock_reminder(mock_session_factory, phone_number):
+    reminder_mock = (
+        mock_session_factory.return_value.query.return_value.get.return_value
+    )
+    reminder_mock.first_name = DEFAULT_FIRST_NAME
+    reminder_mock.phone_number = phone_number
+
+
+class TestActionSendDailyCheckinReminder(TestCase):
+    @patch.dict("os.environ", ENV)
+    def test_action_name(self):
+        self.assertEqual(
+            ActionSendDailyCheckInReminder().name(),
+            "action_send_daily_checkin_reminder",
+        )
+
+    def test_missing_environment_variables(self):
+        with self.assertRaises(expected_exception=Exception):
+            ActionSendDailyCheckInReminder()
+
+    @patch.dict("os.environ", ENV)
+    @patch("actions.action_send_daily_checkin_reminder.session_factory")
+    def test_happy_path(self, mock_session_factory):
+        _mock_reminder(mock_session_factory, DEFAULT_PHONE_NUMBER)
+
+        tracker = _create_tracker()
+        dispatcher = CollectingDispatcher()
+
+        ActionSendDailyCheckInReminder().run(dispatcher, tracker, {})
+
+        self.assertEqual(len(dispatcher.messages), 1)
+        message = dispatcher.messages[0]
+
+        self.assertEqual(message["template"], "utter_checkin_reminder")
+        self.assertEqual(message["first_name"], DEFAULT_FIRST_NAME)
+        self.assertEqual(
+            message["check_in_url"], CHECKIN_BASE_URL + DEFAULT_REMINDER_ID_HASH,
+        )
+
+    @patch.dict("os.environ", ENV)
+    @patch("actions.action_send_daily_checkin_reminder.session_factory")
+    def test_reminder_not_found(self, mock_session_factory):
+        mock_session_factory.return_value.query.return_value.get.return_value = None
+
+        tracker = _create_tracker()
+        dispatcher = CollectingDispatcher()
+
+        with self.assertRaises(expected_exception=ReminderNotFoundException):
+            ActionSendDailyCheckInReminder().run(dispatcher, tracker, {})
+
+    @patch.dict("os.environ", ENV)
+    @patch("actions.action_send_daily_checkin_reminder.session_factory")
+    def test_phone_not_match(self, mock_session_factory):
+        _mock_reminder(mock_session_factory, "99999999999")
+
+        tracker = _create_tracker()
+        dispatcher = CollectingDispatcher()
+
+        with self.assertRaises(expected_exception=InvalidExternalEventException):
+            ActionSendDailyCheckInReminder().run(dispatcher, tracker, {})

--- a/app.yml
+++ b/app.yml
@@ -42,7 +42,7 @@ scale:
 environment:
   COUNTRY_CODE: ca
   ALEMBIC_DATABASE_URI: postgresql+psycopg2://$(SQL_TRACKER_STORE_USER):$(SQL_TRACKER_STORE_PASSWORD)@$(SQL_TRACKER_STORE_URL):5432/$(SQL_TRACKER_STORE_DB)
-  DAILY_CHECKIN_BASE_URL: "https://covid19.dialogue.co/#/rasa/ci"
+  DAILY_CHECKIN_URL_PATTERN: "https://covid19.dialogue.co/?lng={language}#/rasa/ci/{reminder_id}"
   REMINDER_ID_HASHIDS_MIN_LENGTH: 8
 
 environments:

--- a/app.yml
+++ b/app.yml
@@ -42,6 +42,8 @@ scale:
 environment:
   COUNTRY_CODE: ca
   ALEMBIC_DATABASE_URI: postgresql+psycopg2://$(SQL_TRACKER_STORE_USER):$(SQL_TRACKER_STORE_PASSWORD)@$(SQL_TRACKER_STORE_URL):5432/$(SQL_TRACKER_STORE_DB)
+  DAILY_CHECKIN_BASE_URL: "https://covid19.dialogue.co/#/rasa/ci"
+  REMINDER_ID_HASHIDS_MIN_LENGTH: 8
 
 environments:
   dev-ca2:

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -25,6 +25,8 @@ intents:
   - symptom_free
   - send_validation_code:
       triggers: action_send_validation_code
+  - send_daily_checkin_reminder:
+      triggers: action_send_daily_checkin_reminder
 
 entities:
   - province
@@ -47,6 +49,7 @@ actions:
   - action_severe_symptoms_recommendations
   - action_offer_daily_checkin
   - action_send_validation_code
+  - action_send_daily_checkin_reminder
 
 forms:
   - assessment_form

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -436,6 +436,9 @@ responses:
 
   ## Daily check-in
 
+  utter_checkin_reminder:
+    - text: "Hello {first_name}, this is Chloe, for your daily check-in. To continue, please follow that link: {check_in_url}"
+
   utter_greet_daily_checkin:
     - text: Hello Linda, this is Chloe, and I'm checking in to see how you're doing today.
 

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -436,6 +436,9 @@ responses:
 
   ## Daily check-in
 
+  utter_checkin_reminder:
+    - text: "Bonjour {first_name}, ici Chloé, pour votre suivi quotidien. Pour poursuivre, veuillez suivre ce lien: {check_in_url}"
+
   utter_greet_daily_checkin:
     - text: Bonjour Linda, ici Chloé, pour votre suivi quotidien. Voyons voir comment ça va aujourd'hui
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,14 @@ services:
       dockerfile: Dockerfile
     ports:
       - 5055:8080
+    environment:
+        - DAILY_CHECKIN_BASE_URL=http://localhost:3000/#/rasa/ci
+        - REMINDER_ID_HASHIDS_MIN_LENGTH=8
+        - REMINDER_ID_HASHIDS_SALT=abcd1234
+        - SQL_TRACKER_STORE_URL=tracker-store
+        - SQL_TRACKER_STORE_USER=chloe
+        - SQL_TRACKER_STORE_PASSWORD=password
+        - SQL_TRACKER_STORE_DB=chloe
     volumes:
       - ./action-server/actions:/app/actions
       - ./action-server/db:/app/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     ports:
       - 5055:8080
     environment:
-        - DAILY_CHECKIN_BASE_URL=http://localhost:3000/#/rasa/ci
+        - DAILY_CHECKIN_URL_PATTERN=http://localhost:3000/?lng={language}#/rasa/ci/{reminder_id}"
         - REMINDER_ID_HASHIDS_MIN_LENGTH=8
         - REMINDER_ID_HASHIDS_SALT=abcd1234
         - SQL_TRACKER_STORE_URL=tracker-store


### PR DESCRIPTION
## Description
Added external event which will be triggerd by the cron job to send daily check-in SMS.

## Related issues
closes #60 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
