### PR TITLE
fix: rename pre_existing_conditions slot to preconditions (#133)

### DIFF
--- a/action-server/actions/action_explain_preconditions.py
+++ b/action-server/actions/action_explain_preconditions.py
@@ -5,9 +5,9 @@ from rasa_sdk.events import UserUtteranceReverted
 from rasa_sdk.executor import CollectingDispatcher
 
 
-class ActionExplainPreExistingConditions(Action):
+class ActionExplainPreconditions(Action):
     def name(self) -> Text:
-        return "action_explain_pre_existing_conditions"
+        return "action_explain_preconditions"
 
     def run(
         self,
@@ -16,7 +16,7 @@ class ActionExplainPreExistingConditions(Action):
         domain: Dict[Text, Any],
     ) -> List[Dict[Text, Any]]:
 
-        dispatcher.utter_template("utter_explain_pre_existing_conditions", tracker)
-        dispatcher.utter_template("utter_ask_pre_existing_conditions_again", tracker)
+        dispatcher.utter_template("utter_explain_preconditions", tracker)
+        dispatcher.utter_template("utter_ask_preconditions_again", tracker)
 
         return [UserUtteranceReverted()]

--- a/action-server/actions/daily_ci_enroll_form.py
+++ b/action-server/actions/daily_ci_enroll_form.py
@@ -23,7 +23,7 @@ PHONE_TRY_COUNTER_SLOT = "daily_ci_enroll__phone_number_error_counter"
 VALIDATION_CODE_SLOT = "daily_ci_enroll__validation_code"
 VALIDATION_CODE_REFERENCE_SLOT = "daily_ci_enroll__validation_code_reference"
 CODE_TRY_COUNTER_SLOT = "daily_ci_enroll__validation_code_error_counter"
-PRE_EXISTING_CONDITIONS_SLOT = "pre_existing_conditions"
+PRE_EXISTING_CONDITIONS_SLOT = "preconditions"
 HAS_DIALOGUE_SLOT = "has_dialogue"
 
 WANTS_CANCEL_SLOT = "daily_ci_enroll__wants_cancel"
@@ -246,7 +246,7 @@ class DailyCiEnrollForm(FormAction):
 
         return {VALIDATION_CODE_SLOT: None, CODE_TRY_COUNTER_SLOT: try_counter + 1}
 
-    def validate_pre_existing_conditions(
+    def validate_preconditions(
         self,
         value: Union[bool, Text],
         dispatcher: CollectingDispatcher,
@@ -257,7 +257,7 @@ class DailyCiEnrollForm(FormAction):
 
         if value == "dont_know":
             dispatcher.utter_message(
-                template="utter_daily_ci_enroll__note_pre_existing_conditions"
+                template="utter_daily_ci_enroll__note_preconditions"
             )
 
             slot_values[PRE_EXISTING_CONDITIONS_SLOT] = True

--- a/action-server/tests/test_daily_ci_enroll_form.py
+++ b/action-server/tests/test_daily_ci_enroll_form.py
@@ -413,7 +413,7 @@ class TestDailyCiEnrollForm(FormTestCase):
         )
 
         self.assert_templates(
-            ["utter_daily_ci_enroll__thanks", "utter_ask_pre_existing_conditions"]
+            ["utter_daily_ci_enroll__thanks", "utter_ask_preconditions"]
         )
 
     def test_provide_first_invalid_validation_code(self):
@@ -491,7 +491,7 @@ class TestDailyCiEnrollForm(FormTestCase):
 
         self.assert_templates(["utter_daily_ci_enroll__invalid_phone_no_checkin"])
 
-    def test_provide_pre_existing_conditions_affirm(self):
+    def test_provide_preconditions_affirm(self):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: PRE_EXISTING_CONDITIONS_SLOT,
@@ -514,7 +514,7 @@ class TestDailyCiEnrollForm(FormTestCase):
 
         self.assert_templates(["utter_ask_has_dialogue"])
 
-    def test_provide_pre_existing_conditions_deny(self):
+    def test_provide_preconditions_deny(self):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: PRE_EXISTING_CONDITIONS_SLOT,
@@ -537,7 +537,7 @@ class TestDailyCiEnrollForm(FormTestCase):
 
         self.assert_templates(["utter_ask_has_dialogue"],)
 
-    def test_provide_pre_existing_conditions_dont_know(self):
+    def test_provide_preconditions_dont_know(self):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: PRE_EXISTING_CONDITIONS_SLOT,
@@ -559,13 +559,10 @@ class TestDailyCiEnrollForm(FormTestCase):
         )
 
         self.assert_templates(
-            [
-                "utter_daily_ci_enroll__note_pre_existing_conditions",
-                "utter_ask_has_dialogue",
-            ],
+            ["utter_daily_ci_enroll__note_preconditions", "utter_ask_has_dialogue",],
         )
 
-    def test_provide_pre_existing_conditions_explain(self):
+    def test_provide_preconditions_explain(self):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: PRE_EXISTING_CONDITIONS_SLOT,
@@ -574,7 +571,7 @@ class TestDailyCiEnrollForm(FormTestCase):
                 PHONE_NUMBER_SLOT: PHONE_NUMBER,
                 VALIDATION_CODE_SLOT: VALIDATION_CODE,
             },
-            intent="help_pre_existing_conditions",
+            intent="help_preconditions",
         )
 
         with self.assertRaises(ActionExecutionRejection):

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -12,8 +12,8 @@ intents:
   - inform
   - less
   - more
-  - help_pre_existing_conditions:
-      triggers: action_explain_pre_existing_conditions
+  - help_preconditions:
+      triggers: action_explain_preconditions
   - done
   - get_assessment
   - better
@@ -38,7 +38,7 @@ entities:
 
 actions:
   - action_set_risk_level
-  - action_explain_pre_existing_conditions
+  - action_explain_preconditions
   - action_suspect_mild_symptoms_exposure_recommendations
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - action_suspect_moderate_symptoms_recommendations
@@ -119,7 +119,7 @@ slots:
   phone_number:
     type: unfeaturized
 
-  pre_existing_conditions:
+  preconditions:
     type: unfeaturized
 
   has_dialogue:

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -279,7 +279,7 @@ responses:
   utter_ask_daily_ci_enroll__validation_code_error:
     - text: I’m sorry, this is not a valid code. Please try again and enter the 4-digit code that you received by text
 
-  utter_ask_pre_existing_conditions:
+  utter_ask_preconditions:
     - text: Do you have any pre-existing conditions that may affect your immunity?
       buttons:
         - title: Yes
@@ -287,12 +287,12 @@ responses:
         - title: No
           payload: "/deny"
         - title: What are pre-existing conditions?
-          payload: "/help_pre_existing_conditions"
+          payload: "/help_preconditions"
 
-  utter_explain_pre_existing_conditions:
+  utter_explain_preconditions:
     - text: You may be more at risk if you have underlying medical conditions (e.g. heart disease, hypertension, diabetes, chronic respiratory disease, cancer) or if your immune system is compromised from a medical condition or treatment (e.g. chemotherapy)
 
-  utter_ask_pre_existing_conditions_again:
+  utter_ask_preconditions_again:
     - text: Do you have such risk factors or pre-existing conditions?
       buttons:
         - title: Yes
@@ -302,7 +302,7 @@ responses:
         - title: I don't know
           payload: "/dont_know"
 
-  utter_daily_ci_enroll__note_pre_existing_conditions:
+  utter_daily_ci_enroll__note_preconditions:
     - text: If you're not sure, I will put a note in your profile that you might be at risk
 
   utter_ask_has_dialogue:

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -279,7 +279,7 @@ responses:
   utter_ask_daily_ci_enroll__validation_code_error:
     - text: Je suis désolée, ce code n’est pas valide. Veuillez entrer de nouveau le code à 4 chiffres que vous venez de recevoir
 
-  utter_ask_pre_existing_conditions:
+  utter_ask_preconditions:
     - text: Avez-vous des problèmes de santé qui pourraient affecter votre système immunitaire?
       buttons:
         - title: Oui
@@ -287,12 +287,12 @@ responses:
         - title: Non
           payload: "/deny"
         - title: Avez-vous des exemples?
-          payload: "/help_pre_existing_conditions"
+          payload: "/help_preconditions"
 
-  utter_explain_pre_existing_conditions:
+  utter_explain_preconditions:
     - text: "Vous pourriez être plus à risque si vous avez certains problèmes médicaux (par ex.: problèmes cardiaques, hypertension, diabète, maladie respiratoire chronique, cancer) ou si votre système immunitaire est affaibli en raison d'une condition ou d'un traitement médical (par ex.: chimiothérapie)"
 
-  utter_ask_pre_existing_conditions_again:
+  utter_ask_preconditions_again:
     - text: Présentez-vous des facteurs de risque?
       buttons:
         - title: Oui
@@ -302,7 +302,7 @@ responses:
         - title: Je ne sais pas
           payload: "/dont_know"
 
-  utter_daily_ci_enroll__note_pre_existing_conditions:
+  utter_daily_ci_enroll__note_preconditions:
     - text: Si vous ne savez pas, je vais mettre une note à votre profil indiquant que vous pourriez être à risque
 
   utter_ask_has_dialogue:

--- a/integration-tests-en/interactions/bot/daily_ci_enroll/ask_preconditions.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci_enroll/ask_preconditions.jinja
@@ -14,7 +14,7 @@
                 "title": "No"
             },
             {
-                "payload": "/help_pre_existing_conditions",
+                "payload": "/help_preconditions",
                 "title": "What are pre-existing conditions?"
             }
         ]


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Rename pre_existing_conditions slot to preconditions to match the spec

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
Issue [#133](https://github.com/dialoguemd/covidflow/issues/133)

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
