### PR TITLE
feat(flow): adapt and integrate QA to Daily ci (#95)

### DIFF
--- a/action-server/actions/action_qa_goodbye.py
+++ b/action-server/actions/action_qa_goodbye.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, List, Text
+
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import ConversationPaused
+from rasa_sdk.executor import CollectingDispatcher
+
+CANCEL_CI_SLOT = "cancel_ci"
+
+
+class ActionQaGoodbye(Action):
+    def name(self) -> Text:
+        return "action_qa_goodbye"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict[Text, Any]]:
+        if tracker.get_slot(CANCEL_CI_SLOT) is False:
+            dispatcher.utter_message(
+                template="utter_daily_ci__qa__will_contact_tomorrow"
+            )
+
+        dispatcher.utter_message(template="utter_goodbye")
+
+        return [ConversationPaused()]

--- a/action-server/actions/daily_ci_enroll_form.py
+++ b/action-server/actions/daily_ci_enroll_form.py
@@ -196,6 +196,9 @@ class DailyCiEnrollForm(FormAction):
                     template="utter_daily_ci_enroll__validation_code_not_sent_2"
                 )
                 dispatcher.utter_message(template="utter_daily_ci_enroll__continue")
+
+                return {PHONE_NUMBER_SLOT: None, DO_ENROLL_SLOT: False}
+
             return {
                 PHONE_NUMBER_SLOT: phone_number,
                 VALIDATION_CODE_REFERENCE_SLOT: validation_code,

--- a/action-server/actions/daily_ci_feel_better_form.py
+++ b/action-server/actions/daily_ci_feel_better_form.py
@@ -10,6 +10,7 @@ from actions.form_helper import request_next_slot
 FORM_NAME = "daily_ci_feel_better_form"
 
 LAST_SYMPTOMS_SLOT = "last_symptoms"
+SELF_ASSESS_DONE_SLOT = "self_assess_done"
 
 FEEL_WORSE_SLOT = "feel_worse"
 SYMPTOMS_SLOT = "symptoms"
@@ -215,4 +216,4 @@ class DailyCiFeelBetterForm(FormAction):
         domain: Dict[Text, Any],
     ) -> List[Dict]:
 
-        return []
+        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]

--- a/action-server/actions/daily_ci_feel_no_change_form.py
+++ b/action-server/actions/daily_ci_feel_no_change_form.py
@@ -10,6 +10,7 @@ from actions.form_helper import request_next_slot
 FORM_NAME = "daily_ci_feel_no_change_form"
 
 LAST_SYMPTOMS_SLOT = "last_symptoms"
+SELF_ASSESS_DONE_SLOT = "self_assess_done"
 
 FEEL_WORSE_SLOT = "feel_worse"
 SYMPTOMS_SLOT = "symptoms"
@@ -165,4 +166,4 @@ class DailyCiFeelNoChangeForm(FormAction):
                 template="utter_daily_ci__feel_no_change__mild_last_symptoms_recommendation"
             )
 
-        return []
+        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]

--- a/action-server/actions/daily_ci_feel_worse_form.py
+++ b/action-server/actions/daily_ci_feel_worse_form.py
@@ -9,6 +9,8 @@ from actions.form_helper import request_next_slot
 
 FORM_NAME = "daily_ci_feel_worse_form"
 
+SELF_ASSESS_DONE_SLOT = "self_assess_done"
+
 FEEL_WORSE_SLOT = "feel_worse"
 SEVERE_SYMPTOMS_SLOT = "severe_symptoms"
 HAS_FEVER_SLOT = "has_fever"
@@ -197,4 +199,4 @@ class DailyCiFeelWorseForm(FormAction):
         domain: Dict[Text, Any],
     ) -> List[Dict]:
 
-        return []
+        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]

--- a/action-server/tests/test_daily_ci_feel_better_form.py
+++ b/action-server/tests/test_daily_ci_feel_better_form.py
@@ -10,6 +10,7 @@ from actions.daily_ci_feel_better_form import (
     HAS_OTHER_MILD_SYMPTOMS_SLOT,
     IS_SYMPTOM_FREE_SLOT,
     LAST_SYMPTOMS_SLOT,
+    SELF_ASSESS_DONE_SLOT,
     SYMPTOMS_SLOT,
     DailyCiFeelBetterForm,
 )
@@ -194,6 +195,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_DIFF_BREATHING_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -275,6 +277,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -311,6 +314,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -364,6 +368,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(IS_SYMPTOM_FREE_SLOT, True),
                 SlotSet(SYMPTOMS_SLOT, "none"),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -390,6 +395,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(IS_SYMPTOM_FREE_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -494,6 +500,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -528,6 +535,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -555,6 +563,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(IS_SYMPTOM_FREE_SLOT, True),
                 SlotSet(SYMPTOMS_SLOT, "none"),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -579,6 +588,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(IS_SYMPTOM_FREE_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]

--- a/action-server/tests/test_daily_ci_feel_no_change_form.py
+++ b/action-server/tests/test_daily_ci_feel_no_change_form.py
@@ -8,6 +8,7 @@ from actions.daily_ci_feel_no_change_form import (
     HAS_DIFF_BREATHING_SLOT,
     HAS_FEVER_SLOT,
     LAST_SYMPTOMS_SLOT,
+    SELF_ASSESS_DONE_SLOT,
     SYMPTOMS_SLOT,
     DailyCiFeelNoChangeForm,
 )
@@ -187,6 +188,7 @@ class TestDailyCiFeelNoChangeForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_DIFF_BREATHING_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -229,7 +231,12 @@ class TestDailyCiFeelNoChangeForm(FormTestCase):
             slot_set_events.append(SlotSet(SYMPTOMS_SLOT, symptoms))
 
         self.assert_events(
-            slot_set_events + [Form(None), SlotSet(REQUESTED_SLOT, None),],
+            slot_set_events
+            + [
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ],
         )
 
         self.assert_templates(
@@ -258,7 +265,12 @@ class TestDailyCiFeelNoChangeForm(FormTestCase):
         self.run_form(tracker)
 
         self.assert_events(
-            [SlotSet(HAS_COUGH_SLOT, True), Form(None), SlotSet(REQUESTED_SLOT, None),]
+            [
+                SlotSet(HAS_COUGH_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
         )
 
         self.assert_templates(
@@ -288,7 +300,12 @@ class TestDailyCiFeelNoChangeForm(FormTestCase):
         self.run_form(tracker)
 
         self.assert_events(
-            [SlotSet(HAS_COUGH_SLOT, False), Form(None), SlotSet(REQUESTED_SLOT, None),]
+            [
+                SlotSet(HAS_COUGH_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
         )
 
         self.assert_templates(

--- a/action-server/tests/test_daily_ci_feel_worse_form.py
+++ b/action-server/tests/test_daily_ci_feel_worse_form.py
@@ -8,6 +8,7 @@ from actions.daily_ci_feel_worse_form import (
     HAS_DIFF_BREATHING_SLOT,
     HAS_DIFF_BREATHING_WORSENED_SLOT,
     HAS_FEVER_SLOT,
+    SELF_ASSESS_DONE_SLOT,
     SEVERE_SYMPTOMS_SLOT,
     DailyCiFeelWorseForm,
 )
@@ -44,6 +45,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(SEVERE_SYMPTOMS_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -169,6 +171,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_DIFF_BREATHING_WORSENED_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -203,6 +206,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_DIFF_BREATHING_WORSENED_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -267,7 +271,12 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         self.run_form(tracker)
 
         self.assert_events(
-            [SlotSet(HAS_COUGH_SLOT, True), Form(None), SlotSet(REQUESTED_SLOT, None),],
+            [
+                SlotSet(HAS_COUGH_SLOT, True),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ],
         )
 
         self.assert_templates(
@@ -299,6 +308,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         self.assert_events(
             [
                 SlotSet(HAS_COUGH_SLOT, False),
+                SlotSet(SELF_ASSESS_DONE_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -3,10 +3,6 @@
   - utter_greet
   - utter_ask_how_may_i_help
 
-## done
-* done
-  - utter_goodbye
-
 ## suspect - severe symptoms
 * suspect OR get_assessment
   - assessment_form
@@ -40,6 +36,8 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_another_question
+* done
+  - action_qa_goodbye
 
 ## suspect - moderate symptoms no checkin
 * suspect OR get_assessment
@@ -58,6 +56,8 @@
   - action_suspect_moderate_symptoms_final_recommendations
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## suspect - mild symptoms no checkin
 * suspect OR get_assessment
@@ -84,7 +84,7 @@
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
   - utter_try_again_later
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## suspect - mild symptoms
 * suspect OR get_assessment
@@ -111,7 +111,7 @@
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
   - utter_try_again_later
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## suspect - no symptoms contact risk
 * suspect OR get_assessment
@@ -131,6 +131,8 @@
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## suspect - no symptoms contact risk no checkin
 * suspect OR get_assessment
@@ -150,6 +152,8 @@
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## suspect - no symptoms no contact risk
 * suspect OR get_assessment
@@ -171,7 +175,7 @@
   - utter_ask_another_question
 * done
   - utter_please_visit_again
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## tested positive - severe symptoms
 * tested_positive
@@ -199,6 +203,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## tested positive - moderate symptoms
 * tested_positive
@@ -217,6 +223,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## tested positive - mild symptoms worse no check-in
 * tested_positive
@@ -251,6 +259,8 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_another_question
+* done
+  - action_qa_goodbye
 
 ## tested positive - mild symptoms worse
 * tested_positive
@@ -271,6 +281,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## tested positive - mild symptoms not worse no check-in
 * tested_positive
@@ -290,6 +302,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## tested positive - mild symptoms not worse
 * tested_positive
@@ -309,6 +323,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 # tested positive - no symptoms tested less than 14 days no check-in
 * tested_positive
@@ -337,7 +353,7 @@
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
   - utter_try_again_later
-  - utter_goodbye
+  - action_qa_goodbye
 
 # tested positive - no symptoms tested less than 14 days
 * tested_positive
@@ -358,6 +374,8 @@
   - form{"name": null}
   - utter_visit_package
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 # tested positive - cured
 * tested_positive
@@ -387,7 +405,7 @@
   - utter_ask_another_question
 * done
   - utter_please_visit_again
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## return for check-in - severe symptoms
 * checkin_return
@@ -440,7 +458,7 @@
   - utter_ask_another_question
 * done
   - utter_please_visit_again
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## return for check-in - moderate symptoms - no check-in
 * checkin_return
@@ -461,6 +479,8 @@
   - form{"name": "home_assistance_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## return for check-in - mild symptoms - with check-in
 * checkin_return
@@ -478,6 +498,8 @@
   - form{"name": "home_assistance_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## return for check-in - mild symptoms - no check-in
 * checkin_return
@@ -502,6 +524,8 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_another_question
+* done
+  - action_qa_goodbye
 
 ## return for check-in - no symptoms - first symptoms >= 14 days ago
 * checkin_return
@@ -515,6 +539,8 @@
 * more
   - utter_social_distancing_leave_home
   - utter_ask_anything_else
+* done
+  - utter_goodbye
 
 ## return for check-in - no symptoms - first symptoms < 14 days ago
 * checkin_return
@@ -536,7 +562,7 @@
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
   - utter_try_again_later
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## QA - failure - no assessment after
 * greet{"metadata":{}}
@@ -552,7 +578,7 @@
   - utter_ask_assess_after_error
 * deny
   - utter_try_again_later
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## QA - success
 * greet{"metadata":{}}
@@ -565,6 +591,8 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_what_next_after_answer
+* done
+  - action_qa_goodbye
 
 ## QA - success - another question
 * greet{"metadata":{}}
@@ -583,6 +611,8 @@
   - form{"name": null}
   - slot{"question_answering_status": "success"}
   - utter_ask_what_next_after_answer
+* done
+  - action_qa_goodbye
 
 ## QA - need_assessment - no assessment after
 * greet{"metadata":{}}
@@ -598,7 +628,7 @@
   - utter_ask_assess_to_answer
 * done
   - utter_please_visit_again
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## daily check-in - feel worse - moderate symptoms
 * daily_checkin{"metadata":{}}
@@ -609,12 +639,20 @@
   - form{"name": "daily_ci_feel_worse_form"}
   - form{"name": null}
   - slot{"symptoms": "moderate"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_another_question
 * done
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## daily check-in - feel worse - mild symptoms
 * daily_checkin{"metadata":{}}
@@ -625,12 +663,21 @@
   - form{"name": "daily_ci_feel_worse_form"}
   - form{"name": null}
   - slot{"symptoms": "mild"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
 * done
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## daily check-in - feel worse - no symptoms
 * daily_checkin{"metadata":{}}
@@ -641,6 +688,7 @@
   - form{"name": "daily_ci_feel_worse_form"}
   - form{"name": null}
   - slot{"symptoms": "none"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
@@ -657,6 +705,7 @@
   - form{"name": "daily_ci_feel_no_change_form"}
   - form{"name": null}
   - slot{"symptoms": "moderate"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
@@ -673,12 +722,27 @@
   - form{"name": "daily_ci_feel_no_change_form"}
   - form{"name": null}
   - slot{"symptoms": "mild"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_another_question
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "need_assessment"}
+  - utter_need_assessment_already_done
+  - utter_ask_another_question
 * done
-  - utter_goodbye
+  - action_qa_goodbye
 
 ## daily check-in - feel no change - no symptoms
 * daily_checkin{"metadata":{}}
@@ -689,6 +753,7 @@
   - form{"name": "daily_ci_feel_no_change_form"}
   - form{"name": null}
   - slot{"symptoms": "none"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
@@ -705,6 +770,7 @@
   - form{"name": "daily_ci_feel_better_form"}
   - form{"name": null}
   - slot{"symptoms": "moderate"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
@@ -721,6 +787,7 @@
   - form{"name": "daily_ci_feel_better_form"}
   - form{"name": null}
   - slot{"symptoms": "mild"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
@@ -737,9 +804,17 @@
   - form{"name": "daily_ci_feel_better_form"}
   - form{"name": null}
   - slot{"symptoms": "none"}
+  - slot{"self_assess_done": true}
   - daily_ci_keep_or_cancel_form
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
-* done
-  - utter_goodbye
+* ask_question
+  - utter_can_help_with_questions
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - action_qa_goodbye

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -51,6 +51,7 @@ actions:
   - action_severe_symptoms_recommendations
   - action_send_validation_code
   - action_send_daily_checkin_reminder
+  - action_qa_goodbye
 
 forms:
   - assessment_form

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -438,6 +438,9 @@ responses:
         - title: "No I'm done"
           payload: "/done"
 
+  utter_daily_ci__qa__will_contact_tomorrow:
+    - text: I will get in touch with you tomorrow for your daily check-in
+
   ## action self-isolation
 
   utter_symptoms_self_isolate:

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -438,6 +438,9 @@ responses:
         - title: "Non j'ai terminé"
           payload: "/done"
 
+  utter_daily_ci__qa__will_contact_tomorrow:
+    - text: Je vais communiquer avec vous demain pour votre suivi quotidien
+
   ## action self-isolation
 
   utter_symptoms_self_isolate:


### PR DESCRIPTION
## Description
Used the same mechanism as before. To do this, added self_assess_done slot to the daily check-in assessments and added stories

I also corrected a tiny unrelated bug in the daily ci enroll flow.

## Related issues
closes #95 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
