### PR TITLE
fix: wrong cron job name

### DIFF
--- a/job.yml
+++ b/job.yml
@@ -1,4 +1,4 @@
-name: reminders-processing
+name: send-daily-reminders
 engine: ~0.6
 type: cron
 ttl: 270


### PR DESCRIPTION
## Description

oversight while fixing conflict in PR #155 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
