### PR TITLE
feat: fetch user infos on daily ci start (#59)

### DIFF
--- a/action-server/actions/action_initialize_daily_checkin.py
+++ b/action-server/actions/action_initialize_daily_checkin.py
@@ -1,0 +1,130 @@
+import logging
+from typing import Any, Dict, List, Text
+
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import SlotSet
+from rasa_sdk.executor import CollectingDispatcher
+
+from actions.constants import (
+    AGE_OVER_65_SLOT,
+    FIRST_NAME_SLOT,
+    HAS_DIALOGUE_SLOT,
+    LAST_HAS_COUGH_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
+    LAST_HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
+    PRECONDITIONS_SLOT,
+    PROVINCE_SLOT,
+)
+from actions.lib.hashids_util import create_hashids
+from db.assessment import Assessment
+from db.base import session_factory
+from db.reminder import Reminder
+
+logger = logging.getLogger(__name__)
+
+ACTION_NAME = "action_initialize_daily_checkin"
+
+DEFAULT_SYMPTOMS_VALUE = "moderate"
+
+DEFAULT_REMINDER_VALUES = {
+    FIRST_NAME_SLOT: None,
+    PROVINCE_SLOT: None,
+    AGE_OVER_65_SLOT: False,
+    PRECONDITIONS_SLOT: False,
+    HAS_DIALOGUE_SLOT: False,
+}
+
+DEFAULT_ASSESSMENT_VALUES = {
+    LAST_SYMPTOMS_SLOT: DEFAULT_SYMPTOMS_VALUE,
+    LAST_HAS_COUGH_SLOT: False,
+    LAST_HAS_FEVER_SLOT: False,
+    LAST_HAS_DIFF_BREATHING_SLOT: False,
+}
+
+METADATA_SLOT = "metadata"
+REMINDER_ID_PROPERTY_NAME = "reminder_id"
+
+
+class ActionInitializeDailyCheckin(Action):
+    def __init__(self):
+        self.hashids = create_hashids()
+
+    def name(self) -> Text:
+        return ACTION_NAME
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict[Text, Any]]:
+        metadata = tracker.get_slot(METADATA_SLOT)
+        hashed_id = metadata[REMINDER_ID_PROPERTY_NAME]
+        reminder_id = self.hashids.decode(hashed_id)[0]
+
+        session = session_factory()
+
+        user_slots = _get_user_info(session, reminder_id)
+        assessment_slots = _get_last_assessment_slots(session, reminder_id)
+
+        session.close()
+
+        return [
+            SlotSet(name, value)
+            for name, value in {**user_slots, **assessment_slots}.items()
+        ]
+
+
+def _get_user_info(session, reminder_id: str) -> dict:
+    try:
+        reminder = session.query(Reminder).get(reminder_id)
+    except:
+        reminder = None
+
+    if reminder is None:
+        logger.warning(
+            f"Reminder with id '{reminder_id}' does not exist. Could not fetch user profile. Filling up with defaults."
+        )
+        return DEFAULT_REMINDER_VALUES
+
+    return {
+        FIRST_NAME_SLOT: reminder.first_name,
+        PROVINCE_SLOT: reminder.province,
+        AGE_OVER_65_SLOT: _fill_false(reminder.age_over_65),
+        PRECONDITIONS_SLOT: _fill_false(reminder.preconditions),
+        HAS_DIALOGUE_SLOT: _fill_false(reminder.has_dialogue),
+    }
+
+
+def _get_last_assessment_slots(session, reminder_id: str) -> dict:
+    try:
+        assessment = (
+            session.query(Assessment)
+            .filter_by(reminder_id=reminder_id)
+            .order_by(Assessment.completed_at.desc())
+            .first()
+        )
+    except:
+        assessment = None
+
+    if assessment is None:
+        logger.error(
+            f"Could not fetch last assessment for reminder id: {reminder_id}. Filling up last assessment values with defaults."
+        )
+        return DEFAULT_ASSESSMENT_VALUES
+
+    return {
+        LAST_SYMPTOMS_SLOT: _fill(assessment.symptoms, DEFAULT_SYMPTOMS_VALUE),
+        LAST_HAS_COUGH_SLOT: _fill_false(assessment.has_cough),
+        LAST_HAS_FEVER_SLOT: _fill_false(assessment.has_fever),
+        LAST_HAS_DIFF_BREATHING_SLOT: _fill_false(assessment.has_diff_breathing),
+    }
+
+
+def _fill(value, default_value):
+    return value if value is not None else default_value
+
+
+def _fill_false(value):
+    return _fill(value, False)

--- a/action-server/actions/constants.py
+++ b/action-server/actions/constants.py
@@ -1,1 +1,30 @@
 PROVINCES_WITH_211 = ["bc", "ab", "sk", "mb", "on", "qc", "ns"]
+
+
+SELF_ASSESS_DONE_SLOT = "self_assess_done"
+
+LAST_SYMPTOMS_SLOT = "last_symptoms"
+LAST_HAS_FEVER_SLOT = "last_has_fever"
+LAST_HAS_COUGH_SLOT = "last_has_cough"
+LAST_HAS_DIFF_BREATHING_SLOT = "last_has_diff_breathing"
+
+LAST_ASSESSMENT_SLOTS = [
+    LAST_SYMPTOMS_SLOT,
+    LAST_HAS_FEVER_SLOT,
+    LAST_HAS_COUGH_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
+]
+
+
+FEEL_WORSE_SLOT = "feel_worse"
+SYMPTOMS_SLOT = "symptoms"
+HAS_FEVER_SLOT = "has_fever"
+HAS_COUGH_SLOT = "has_cough"
+HAS_DIFF_BREATHING_SLOT = "has_diff_breathing"
+
+
+FIRST_NAME_SLOT = "first_name"
+PRECONDITIONS_SLOT = "preconditions"
+HAS_DIALOGUE_SLOT = "has_dialogue"
+PROVINCE_SLOT = "province"
+AGE_OVER_65_SLOT = "age_over_65"

--- a/action-server/actions/daily_ci_assessment_common.py
+++ b/action-server/actions/daily_ci_assessment_common.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from rasa_sdk import Tracker
+from rasa_sdk.events import SlotSet
+
+from actions.constants import LAST_ASSESSMENT_SLOTS, SELF_ASSESS_DONE_SLOT
+from actions.lib.persistence import store_assessment
+
+LAST_PREFIX = "last_"
+
+
+def submit_daily_ci_assessment(tracker: Tracker) -> List[dict]:
+    events = [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
+
+    ## Filling empty slots with previous day values
+    slots_to_add = {}
+    for last_slot in LAST_ASSESSMENT_SLOTS:
+        current_slot = last_slot.replace(LAST_PREFIX, "")
+        if tracker.get_slot(current_slot) is None:
+            value = tracker.get_slot(last_slot)
+            slots_to_add.update({current_slot: value})
+
+    store_assessment({**tracker.current_slot_values(), **slots_to_add})
+
+    return events + [SlotSet(key, value) for key, value in slots_to_add.items()]

--- a/action-server/actions/daily_ci_feel_better_form.py
+++ b/action-server/actions/daily_ci_feel_better_form.py
@@ -5,19 +5,18 @@ from rasa_sdk.events import EventType, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import FormAction
 
+from actions.constants import (
+    FEEL_WORSE_SLOT,
+    HAS_COUGH_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
+    SYMPTOMS_SLOT,
+)
+from actions.daily_ci_assessment_common import submit_daily_ci_assessment
 from actions.form_helper import request_next_slot
-from actions.lib.persistence import store_assessment
 
 FORM_NAME = "daily_ci_feel_better_form"
-
-LAST_SYMPTOMS_SLOT = "last_symptoms"
-SELF_ASSESS_DONE_SLOT = "self_assess_done"
-
-FEEL_WORSE_SLOT = "feel_worse"
-SYMPTOMS_SLOT = "symptoms"
-HAS_FEVER_SLOT = "has_fever"
-HAS_COUGH_SLOT = "has_cough"
-HAS_DIFF_BREATHING_SLOT = "has_diff_breathing"
 
 HAS_OTHER_MILD_SYMPTOMS_SLOT = "daily_ci__feel_better__has_other_mild_symptoms"
 IS_SYMPTOM_FREE_SLOT = "daily_ci__feel_better__is_symptom_free"
@@ -216,5 +215,5 @@ class DailyCiFeelBetterForm(FormAction):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> List[Dict]:
-        store_assessment(tracker.current_slot_values())
-        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
+
+        return submit_daily_ci_assessment(tracker)

--- a/action-server/actions/daily_ci_feel_no_change_form.py
+++ b/action-server/actions/daily_ci_feel_no_change_form.py
@@ -5,19 +5,18 @@ from rasa_sdk.events import EventType, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import FormAction
 
+from actions.constants import (
+    FEEL_WORSE_SLOT,
+    HAS_COUGH_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
+    SYMPTOMS_SLOT,
+)
+from actions.daily_ci_assessment_common import submit_daily_ci_assessment
 from actions.form_helper import request_next_slot
-from actions.lib.persistence import store_assessment
 
 FORM_NAME = "daily_ci_feel_no_change_form"
-
-LAST_SYMPTOMS_SLOT = "last_symptoms"
-SELF_ASSESS_DONE_SLOT = "self_assess_done"
-
-FEEL_WORSE_SLOT = "feel_worse"
-SYMPTOMS_SLOT = "symptoms"
-HAS_FEVER_SLOT = "has_fever"
-HAS_DIFF_BREATHING_SLOT = "has_diff_breathing"
-HAS_COUGH_SLOT = "has_cough"
 
 
 class DailyCiFeelNoChangeForm(FormAction):
@@ -167,5 +166,4 @@ class DailyCiFeelNoChangeForm(FormAction):
                 template="utter_daily_ci__feel_no_change__mild_last_symptoms_recommendation"
             )
 
-        store_assessment(tracker.current_slot_values())
-        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
+        return submit_daily_ci_assessment(tracker)

--- a/action-server/actions/daily_ci_feel_worse_form.py
+++ b/action-server/actions/daily_ci_feel_worse_form.py
@@ -5,19 +5,18 @@ from rasa_sdk.events import EventType, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import FormAction
 
+from actions.constants import (
+    FEEL_WORSE_SLOT,
+    HAS_COUGH_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_FEVER_SLOT,
+)
+from actions.daily_ci_assessment_common import submit_daily_ci_assessment
 from actions.form_helper import request_next_slot
-from actions.lib.persistence import store_assessment
 
 FORM_NAME = "daily_ci_feel_worse_form"
 
-SELF_ASSESS_DONE_SLOT = "self_assess_done"
-
-FEEL_WORSE_SLOT = "feel_worse"
 SEVERE_SYMPTOMS_SLOT = "severe_symptoms"
-HAS_FEVER_SLOT = "has_fever"
-HAS_DIFF_BREATHING_SLOT = "has_diff_breathing"
-HAS_COUGH_SLOT = "has_cough"
-
 HAS_DIFF_BREATHING_WORSENED_SLOT = "daily_ci__feel_worse__has_diff_breathing_worsened"
 
 
@@ -199,5 +198,5 @@ class DailyCiFeelWorseForm(FormAction):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> List[Dict]:
-        store_assessment(tracker.current_slot_values())
-        return [SlotSet(SELF_ASSESS_DONE_SLOT, True)]
+
+        return submit_daily_ci_assessment(tracker)

--- a/action-server/db/assessment.py
+++ b/action-server/db/assessment.py
@@ -81,7 +81,7 @@ class Assessment(Base):
 
     @property
     def symptoms(self):
-        return self.attributes[SYMPTOMS_ATTRIBUTE]
+        return self.attributes.get(SYMPTOMS_ATTRIBUTE)
 
     @symptoms.setter
     def symptoms(self, symptoms):
@@ -89,7 +89,7 @@ class Assessment(Base):
 
     @property
     def has_fever(self):
-        return self.attributes[HAS_FEVER_ATTRIBUTE]
+        return self.attributes.get(HAS_FEVER_ATTRIBUTE)
 
     @has_fever.setter
     def has_fever(self, has_fever):
@@ -97,7 +97,7 @@ class Assessment(Base):
 
     @property
     def has_cough(self):
-        return self.attributes[HAS_COUGH_ATTRIBUTE]
+        return self.attributes.get(HAS_COUGH_ATTRIBUTE)
 
     @has_cough.setter
     def has_cough(self, has_cough):
@@ -105,7 +105,7 @@ class Assessment(Base):
 
     @property
     def has_diff_breathing(self):
-        return self.attributes[HAS_DIFF_BREATHING_ATTRIBUTE]
+        return self.attributes.get(HAS_DIFF_BREATHING_ATTRIBUTE)
 
     @has_diff_breathing.setter
     def has_diff_breathing(self, has_diff_breathing):
@@ -113,7 +113,7 @@ class Assessment(Base):
 
     @property
     def feel_worse(self):
-        return self.attributes[FEEL_WORSE_ATTRIBUTE]
+        return self.attributes.get(FEEL_WORSE_ATTRIBUTE)
 
     @feel_worse.setter
     def feel_worse(self, feel_worse):

--- a/action-server/db/reminder.py
+++ b/action-server/db/reminder.py
@@ -123,7 +123,7 @@ class Reminder(Base):
 
     @property
     def first_name(self):
-        return self.attributes[FIRST_NAME_ATTRIBUTE]
+        return self.attributes.get(FIRST_NAME_ATTRIBUTE)
 
     @first_name.setter
     def first_name(self, first_name):
@@ -131,7 +131,7 @@ class Reminder(Base):
 
     @property
     def phone_number(self):
-        return self.attributes[PHONE_NUMBER_ATTRIBUTE]
+        return self.attributes.get(PHONE_NUMBER_ATTRIBUTE)
 
     @phone_number.setter
     def phone_number(self, phone_number):
@@ -139,7 +139,7 @@ class Reminder(Base):
 
     @property
     def language(self):
-        return self.attributes[LANGUAGE_ATTRIBUTE]
+        return self.attributes.get(LANGUAGE_ATTRIBUTE)
 
     @language.setter
     def language(self, language):
@@ -147,7 +147,7 @@ class Reminder(Base):
 
     @property
     def province(self):
-        return self.attributes[PROVINCE_ATTRIBUTE]
+        return self.attributes.get(PROVINCE_ATTRIBUTE)
 
     @province.setter
     def province(self, province):
@@ -155,7 +155,7 @@ class Reminder(Base):
 
     @property
     def age_over_65(self):
-        return self.attributes[AGE_OVER_65_ATTRIBUTE]
+        return self.attributes.get(AGE_OVER_65_ATTRIBUTE)
 
     @age_over_65.setter
     def age_over_65(self, age_over_65):
@@ -163,7 +163,7 @@ class Reminder(Base):
 
     @property
     def preconditions(self):
-        return self.attributes[PRECONDITIONS_ATTRIBUTE]
+        return self.attributes.get(PRECONDITIONS_ATTRIBUTE)
 
     @preconditions.setter
     def preconditions(self, preconditions):
@@ -171,7 +171,7 @@ class Reminder(Base):
 
     @property
     def has_dialogue(self):
-        return self.attributes[HAS_DIALOGUE_ATTRIBUTE]
+        return self.attributes.get(HAS_DIALOGUE_ATTRIBUTE)
 
     @has_dialogue.setter
     def has_dialogue(self, has_dialogue):

--- a/action-server/tests/test_action_initialize_daily_checkin.py
+++ b/action-server/tests/test_action_initialize_daily_checkin.py
@@ -1,0 +1,153 @@
+from collections import namedtuple
+from unittest.mock import patch
+
+from hashids import Hashids
+from rasa_sdk import Tracker
+from rasa_sdk.events import SlotSet
+
+from actions.action_initialize_daily_checkin import ActionInitializeDailyCheckin
+from actions.constants import (
+    AGE_OVER_65_SLOT,
+    FIRST_NAME_SLOT,
+    HAS_COUGH_SLOT,
+    HAS_DIALOGUE_SLOT,
+    HAS_DIFF_BREATHING_SLOT,
+    HAS_FEVER_SLOT,
+    LAST_HAS_COUGH_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
+    LAST_HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
+    PRECONDITIONS_SLOT,
+    PROVINCE_SLOT,
+    SYMPTOMS_SLOT,
+)
+from tests.action_helper import ActionTestCase
+
+HASHIDS_SALT = "abcd1234"
+HASHIDS_MIN_LENGTH = 4
+hashids = Hashids(HASHIDS_SALT, min_length=HASHIDS_MIN_LENGTH)
+
+NON_DEFAULT_REMINDER_VALUES = {
+    FIRST_NAME_SLOT: "Robin",
+    PROVINCE_SLOT: "nu",
+    AGE_OVER_65_SLOT: True,
+    PRECONDITIONS_SLOT: True,
+    HAS_DIALOGUE_SLOT: True,
+}
+
+NON_DEFAULT_ASSESSMENT_VALUES = {
+    LAST_SYMPTOMS_SLOT: "none",
+    LAST_HAS_COUGH_SLOT: False,
+    LAST_HAS_FEVER_SLOT: False,
+    LAST_HAS_DIFF_BREATHING_SLOT: False,
+}
+
+NON_DEFAULT_ASSESSMENT_VALUES_ENTRY = {
+    SYMPTOMS_SLOT: "none",
+    HAS_COUGH_SLOT: False,
+    HAS_DIFF_BREATHING_SLOT: False,
+    HAS_FEVER_SLOT: False,
+}
+
+DEFAULT_VALUES = {
+    FIRST_NAME_SLOT: None,
+    PROVINCE_SLOT: None,
+    AGE_OVER_65_SLOT: False,
+    PRECONDITIONS_SLOT: False,
+    HAS_DIALOGUE_SLOT: False,
+    LAST_SYMPTOMS_SLOT: "moderate",
+    LAST_HAS_COUGH_SLOT: False,
+    LAST_HAS_FEVER_SLOT: False,
+    LAST_HAS_DIFF_BREATHING_SLOT: False,
+}
+
+DEFAULT_REMINDER_ID = 1
+DEFAULT_REMINDER_ID_HASH = hashids.encode(1)
+
+ENV = {
+    "REMINDER_ID_HASHIDS_SALT": HASHIDS_SALT,
+    "REMINDER_ID_HASHIDS_MIN_LENGTH": str(HASHIDS_MIN_LENGTH),
+}
+
+
+def _create_tracker(reminder_id=DEFAULT_REMINDER_ID_HASH) -> Tracker:
+    return Tracker(
+        "sender_id",
+        {"metadata": {"reminder_id": reminder_id}},
+        {},
+        [],
+        False,
+        None,
+        {},
+        "action_listen",
+    )
+
+
+class TestActionInitializeDailyCheckin(ActionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+
+        self.patcher = patch.dict("os.environ", ENV)
+        self.patcher.start()
+        self.action = ActionInitializeDailyCheckin()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patcher.stop()
+
+    def test_action_name(self):
+        self.assertEqual(
+            ActionInitializeDailyCheckin().name(), "action_initialize_daily_checkin",
+        )
+
+    @patch("actions.action_initialize_daily_checkin.session_factory")
+    def test_happy_path(self, mock_session_factory):
+        mock_session_factory.return_value.query.return_value.get.return_value = namedtuple(
+            "Reminder", NON_DEFAULT_REMINDER_VALUES.keys()
+        )(
+            *NON_DEFAULT_REMINDER_VALUES.values()
+        )
+        mock_session_factory.return_value.query.return_value.filter_by.return_value.order_by.return_value.first.return_value = namedtuple(
+            "Assessment", NON_DEFAULT_ASSESSMENT_VALUES_ENTRY.keys()
+        )(
+            *NON_DEFAULT_ASSESSMENT_VALUES_ENTRY.values()
+        )
+
+        tracker = _create_tracker()
+
+        self.run_action(tracker)
+
+        self.assert_templates([])
+
+        expected_slots = {
+            **NON_DEFAULT_REMINDER_VALUES,
+            **NON_DEFAULT_ASSESSMENT_VALUES,
+        }
+
+        self.assert_events(
+            [SlotSet(slot, value) for slot, value in expected_slots.items()]
+        )
+
+        mock_session_factory.return_value.close.assert_called()
+
+    @patch("actions.action_initialize_daily_checkin.session_factory")
+    def test_reminder_not_found_default_user_values(self, mock_session_factory):
+        mock_session_factory.return_value.query.return_value.get.return_value = None
+        mock_session_factory.return_value.query.return_value.filter_by.return_value.order_by.return_value.first.return_value = (
+            None
+        )
+
+        tracker = _create_tracker()
+
+        self.run_action(tracker)
+
+        self.assert_templates([])
+
+        expected_slots = DEFAULT_VALUES
+
+        self.assert_events(
+            [SlotSet(slot, value) for slot, value in expected_slots.items()]
+        )
+
+        mock_session_factory.return_value.close.assert_called()

--- a/action-server/tests/test_daily_ci_feel_better_form.py
+++ b/action-server/tests/test_daily_ci_feel_better_form.py
@@ -3,17 +3,20 @@ from unittest.mock import patch
 from rasa_sdk.events import Form, SlotSet
 from rasa_sdk.forms import REQUESTED_SLOT
 
-from actions.daily_ci_feel_better_form import (
+from actions.constants import (
     FEEL_WORSE_SLOT,
-    FORM_NAME,
     HAS_COUGH_SLOT,
     HAS_DIFF_BREATHING_SLOT,
     HAS_FEVER_SLOT,
-    HAS_OTHER_MILD_SYMPTOMS_SLOT,
-    IS_SYMPTOM_FREE_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
     LAST_SYMPTOMS_SLOT,
     SELF_ASSESS_DONE_SLOT,
     SYMPTOMS_SLOT,
+)
+from actions.daily_ci_feel_better_form import (
+    FORM_NAME,
+    HAS_OTHER_MILD_SYMPTOMS_SLOT,
+    IS_SYMPTOM_FREE_SLOT,
     DailyCiFeelBetterForm,
 )
 from tests.form_helper import FormTestCase
@@ -24,7 +27,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         super().setUp()
         self.form = DailyCiFeelBetterForm()
 
-        self.patcher = patch("actions.daily_ci_feel_better_form.store_assessment")
+        self.patcher = patch("actions.daily_ci_assessment_common.store_assessment")
         self.mock_store_assessment = self.patcher.start()
 
     def tearDown(self):
@@ -205,6 +208,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(HAS_DIFF_BREATHING_SLOT, True),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -497,6 +501,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 LAST_SYMPTOMS_SLOT: "mild",
+                LAST_HAS_DIFF_BREATHING_SLOT: False,
                 REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
                 HAS_FEVER_SLOT: fever,
                 HAS_COUGH_SLOT: cough,
@@ -510,6 +515,8 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, True),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "mild"),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -534,6 +541,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 LAST_SYMPTOMS_SLOT: "mild",
+                LAST_HAS_DIFF_BREATHING_SLOT: False,
                 REQUESTED_SLOT: HAS_OTHER_MILD_SYMPTOMS_SLOT,
                 HAS_FEVER_SLOT: fever,
                 HAS_COUGH_SLOT: cough,
@@ -547,6 +555,8 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(HAS_OTHER_MILD_SYMPTOMS_SLOT, False),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "mild"),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -562,6 +572,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 LAST_SYMPTOMS_SLOT: "mild",
+                LAST_HAS_DIFF_BREATHING_SLOT: False,
                 REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
                 HAS_FEVER_SLOT: False,
                 HAS_COUGH_SLOT: False,
@@ -577,6 +588,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
                 SlotSet(IS_SYMPTOM_FREE_SLOT, True),
                 SlotSet(SYMPTOMS_SLOT, "none"),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]
@@ -590,6 +602,7 @@ class TestDailyCiFeelBetterForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 LAST_SYMPTOMS_SLOT: "mild",
+                LAST_HAS_DIFF_BREATHING_SLOT: False,
                 REQUESTED_SLOT: IS_SYMPTOM_FREE_SLOT,
                 HAS_FEVER_SLOT: False,
                 HAS_COUGH_SLOT: False,
@@ -604,6 +617,8 @@ class TestDailyCiFeelBetterForm(FormTestCase):
             [
                 SlotSet(IS_SYMPTOM_FREE_SLOT, False),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "mild"),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ]

--- a/action-server/tests/test_daily_ci_feel_worse_form.py
+++ b/action-server/tests/test_daily_ci_feel_worse_form.py
@@ -3,14 +3,21 @@ from unittest.mock import patch
 from rasa_sdk.events import Form, SlotSet
 from rasa_sdk.forms import REQUESTED_SLOT
 
-from actions.daily_ci_feel_worse_form import (
+from actions.constants import (
     FEEL_WORSE_SLOT,
-    FORM_NAME,
     HAS_COUGH_SLOT,
     HAS_DIFF_BREATHING_SLOT,
-    HAS_DIFF_BREATHING_WORSENED_SLOT,
     HAS_FEVER_SLOT,
+    LAST_HAS_COUGH_SLOT,
+    LAST_HAS_DIFF_BREATHING_SLOT,
+    LAST_HAS_FEVER_SLOT,
+    LAST_SYMPTOMS_SLOT,
     SELF_ASSESS_DONE_SLOT,
+    SYMPTOMS_SLOT,
+)
+from actions.daily_ci_feel_worse_form import (
+    FORM_NAME,
+    HAS_DIFF_BREATHING_WORSENED_SLOT,
     SEVERE_SYMPTOMS_SLOT,
     DailyCiFeelWorseForm,
 )
@@ -22,7 +29,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         super().setUp()
         self.form = DailyCiFeelWorseForm()
 
-        self.patcher = patch("actions.daily_ci_feel_worse_form.store_assessment")
+        self.patcher = patch("actions.daily_ci_assessment_common.store_assessment")
         self.mock_store_assessment = self.patcher.start()
 
     def tearDown(self):
@@ -46,7 +53,14 @@ class TestDailyCiFeelWorseForm(FormTestCase):
 
     def test_severe_symptoms(self):
         tracker = self.create_tracker(
-            slots={REQUESTED_SLOT: SEVERE_SYMPTOMS_SLOT}, intent="affirm"
+            slots={
+                REQUESTED_SLOT: SEVERE_SYMPTOMS_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
+                LAST_HAS_FEVER_SLOT: True,
+                LAST_HAS_DIFF_BREATHING_SLOT: True,
+                LAST_HAS_COUGH_SLOT: True,
+            },
+            intent="affirm",
         )
 
         self.run_form(tracker)
@@ -55,6 +69,10 @@ class TestDailyCiFeelWorseForm(FormTestCase):
             [
                 SlotSet(SEVERE_SYMPTOMS_SLOT, True),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
+                SlotSet(HAS_FEVER_SLOT, True),
+                SlotSet(HAS_COUGH_SLOT, True),
+                SlotSet(HAS_DIFF_BREATHING_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -168,6 +186,8 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: HAS_DIFF_BREATHING_WORSENED_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
+                LAST_HAS_COUGH_SLOT: False,
                 SEVERE_SYMPTOMS_SLOT: False,
                 HAS_FEVER_SLOT: fever,
                 HAS_DIFF_BREATHING_SLOT: True,
@@ -181,6 +201,8 @@ class TestDailyCiFeelWorseForm(FormTestCase):
             [
                 SlotSet(HAS_DIFF_BREATHING_WORSENED_SLOT, True),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
+                SlotSet(HAS_COUGH_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -203,6 +225,8 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: HAS_DIFF_BREATHING_WORSENED_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
+                LAST_HAS_COUGH_SLOT: False,
                 SEVERE_SYMPTOMS_SLOT: False,
                 HAS_FEVER_SLOT: fever,
                 HAS_DIFF_BREATHING_SLOT: True,
@@ -216,6 +240,8 @@ class TestDailyCiFeelWorseForm(FormTestCase):
             [
                 SlotSet(HAS_DIFF_BREATHING_WORSENED_SLOT, False),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
+                SlotSet(HAS_COUGH_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -238,6 +264,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: HAS_DIFF_BREATHING_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
                 SEVERE_SYMPTOMS_SLOT: False,
                 HAS_FEVER_SLOT: fever,
             },
@@ -270,6 +297,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: HAS_COUGH_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
                 SEVERE_SYMPTOMS_SLOT: False,
                 HAS_FEVER_SLOT: fever,
                 HAS_DIFF_BREATHING_SLOT: False,
@@ -283,6 +311,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
             [
                 SlotSet(HAS_COUGH_SLOT, True),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],
@@ -307,6 +336,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
         tracker = self.create_tracker(
             slots={
                 REQUESTED_SLOT: HAS_COUGH_SLOT,
+                LAST_SYMPTOMS_SLOT: "moderate",
                 SEVERE_SYMPTOMS_SLOT: False,
                 HAS_FEVER_SLOT: fever,
                 HAS_DIFF_BREATHING_SLOT: False,
@@ -320,6 +350,7 @@ class TestDailyCiFeelWorseForm(FormTestCase):
             [
                 SlotSet(HAS_COUGH_SLOT, False),
                 SlotSet(SELF_ASSESS_DONE_SLOT, True),
+                SlotSet(SYMPTOMS_SLOT, "moderate"),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
             ],

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -658,6 +658,7 @@
 
 ## daily check-in - feel worse - moderate symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -685,6 +686,7 @@
 
 ## daily check-in - feel worse - mild symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -713,6 +715,7 @@
 
 ## daily check-in - feel worse - no symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -733,6 +736,7 @@
 
 ## daily check-in - feel no change - moderate symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -753,6 +757,7 @@
 
 ## daily check-in - feel no change - mild symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -787,6 +792,7 @@
 
 ## daily check-in - feel no change - no symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -807,6 +813,7 @@
 
 ## daily check-in - feel better - moderate symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -827,6 +834,7 @@
 
 ## daily check-in - feel better - mild symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue
@@ -847,6 +855,7 @@
 
 ## daily check-in - feel better - no symptoms
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * continue

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -38,6 +38,7 @@ entities:
 
 actions:
   - action_visit_package
+  - action_initialize_daily_checkin
   - action_daily_ci_early_opt_out
   - action_daily_ci_recommendations
   - action_explain_preconditions
@@ -99,9 +100,6 @@ slots:
       - moderate
       - mild
       - none
-
-  last_symptoms:
-    type: unfeaturized
 
   has_cough:
     type: unfeaturized
@@ -167,6 +165,18 @@ slots:
     type: unfeaturized
 
   provincial_811:
+    type: unfeaturized
+
+  last_symptoms:
+    type: unfeaturized
+
+  last_has_cough:
+    type: unfeaturized
+
+  last_has_fever:
+    type: unfeaturized
+
+  last_has_diff_breathing:
     type: unfeaturized
 
   daily_ci_enroll__do_enroll:

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -504,7 +504,7 @@ responses:
     - text: "Hello {first_name}, this is Chloe, for your daily check-in. To continue, please follow that link: {check_in_url}"
 
   utter_daily_ci__greet:
-    - text: Hello Linda, this is Chloe, and I'm checking in to see how you're doing today
+    - text: Hello {first_name}, this is Chloe, and I'm checking in to see how you're doing today
 
   utter_ask_daily_ci__feel:
     - text: First, compared to yesterday, how do you feel?

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -504,7 +504,7 @@ responses:
     - text: "Bonjour {first_name}, ici Chloé, pour votre suivi quotidien. Pour poursuivre, veuillez suivre ce lien: {check_in_url}"
 
   utter_daily_ci__greet:
-    - text: Bonjour Linda, ici Chloé, pour votre suivi quotidien. Voyons voir comment ça va aujourd'hui
+    - text: Bonjour {first_name}, ici Chloé, pour votre suivi quotidien. Voyons voir comment ça va aujourd'hui
 
   utter_ask_daily_ci__feel:
     - text: D'abord, comment vous sentez-vous par rapport à hier?


### PR DESCRIPTION
## Description

Saves useful reminder and assessment attributes in slots at the beginning of daily check-in.
After assessment, saves empty attributes with preceding day's values.

## Related issues

closes #59 

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
