### PR TITLE
fix: Reminder.create_from_slot_values not working when metadata=None

### DIFF
--- a/action-server/db/reminder.py
+++ b/action-server/db/reminder.py
@@ -90,7 +90,7 @@ class Reminder(Base):
 
     @staticmethod
     def create_from_slot_values(slot_values: Dict[Text, Any]):
-        metadata = slot_values.get(METADATA_SLOT, {})
+        metadata = slot_values.get(METADATA_SLOT) or {}
         timezone = metadata.get(TIMEZONE_METADATA_PROPERTY, None)
 
         reminder = Reminder(timezone)

--- a/action-server/tests/db/test_reminder.py
+++ b/action-server/tests/db/test_reminder.py
@@ -32,3 +32,17 @@ class TestReminder(TestCase):
         self.assertEqual(_uniformize_timezone("america/toronto"), "America/Toronto")
         self.assertEqual(_uniformize_timezone("does-not-exist"), None)
         self.assertEqual(_uniformize_timezone(None), None)
+
+    def test_metadata_none(self):
+        reminder = Reminder.create_from_slot_values(
+            {
+                METADATA_SLOT: None,
+                PHONE_NUMBER_SLOT: PHONE_NUMBER,
+                FIRST_NAME_SLOT: NAME,
+            }
+        )
+        expected_reminder = Reminder(timezone=None)
+        expected_reminder.phone_number = PHONE_NUMBER
+        expected_reminder.first_name = NAME
+
+        self.assertEqual(reminder, expected_reminder)


### PR DESCRIPTION

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
