### PR TITLE
fix: missing daily ci initialization in stories

### DIFF
--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -632,6 +632,7 @@
 
 ## daily check-in - early opt out - done
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * opt_out
@@ -642,6 +643,7 @@
 
 ## daily check-in - early opt out - QA
 * daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__cancel_ci
 * opt_out


### PR DESCRIPTION
## Description
Some stories didn't have the `action_initialize_daily_checkin` due to rebase, which created an alternating result depending on the training. either initializing or not.

## Related issues

None. I was too fast to fix ;)

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
