### PR TITLE
chore: do not send reminder for test profiles (#222)

### DIFF
--- a/action-server/covidflow/actions/action_send_daily_checkin_reminder.py
+++ b/action-server/covidflow/actions/action_send_daily_checkin_reminder.py
@@ -13,6 +13,7 @@ from covidflow.exceptions import (
     ReminderNotFoundException,
 )
 from covidflow.utils.hashids_util import create_hashids
+from covidflow.utils.phone_number_validation import is_test_phone_number
 
 from .lib.log_util import bind_logger
 
@@ -87,6 +88,12 @@ class ActionSendDailyCheckInReminder(Action):
         first_name = reminder.first_name
         phone_number = reminder.phone_number
         language = reminder.language
+
+        if is_test_phone_number(phone_number):
+            logger.debug(
+                f"Reminder with test phone number: {phone_number}, not sending reminder"
+            )
+            return
 
         if conversation_id != phone_number:
             raise InvalidExternalEventException(

--- a/action-server/tests/actions/test_action_send_daily_checkin_reminder.py
+++ b/action-server/tests/actions/test_action_send_daily_checkin_reminder.py
@@ -111,6 +111,22 @@ class TestActionSendDailyCheckinReminder(TestCase):
 
     @patch.dict("os.environ", ENV)
     @patch("covidflow.actions.action_send_daily_checkin_reminder.session_factory")
+    @patch("covidflow.actions.action_send_daily_checkin_reminder.datetime")
+    def test_555_phone_number_no_reminder(self, mock_datetime, mock_session_factory):
+        _mock_reminder(mock_session_factory, "12345556789")
+        mock_datetime.utcnow.return_value = DEFAULT_NOW
+
+        tracker = _create_tracker()
+        dispatcher = CollectingDispatcher()
+
+        ActionSendDailyCheckInReminder().run(dispatcher, tracker, {})
+
+        self.assertListEqual(dispatcher.messages, [])
+        mock_session_factory.return_value.commit.assert_called()
+        mock_session_factory.return_value.close.assert_called()
+
+    @patch.dict("os.environ", ENV)
+    @patch("covidflow.actions.action_send_daily_checkin_reminder.session_factory")
     def test_reminder_not_found(self, mock_session_factory):
         mock_session_factory.return_value.query.return_value.get.return_value = None
 


### PR DESCRIPTION
## Description

Changed the action_send_checkin_reminder to ignore 555 numbers

## Related issues

closes #222 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
