### PR TITLE
fix: add dialogue.co domain 

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -51,5 +51,16 @@ environments:
     environment:
       TWILIO_NUMBER: "+14382996778"
   prod-ca:
+    components:
+      core-en:
+        public:
+          ingress:
+            additionalHostnames:
+              - covidflow-core-en.dialogue.co
+      core-fr:
+        public:
+          ingress:
+            additionalHostnames:
+              - covidflow-core-fr.dialogue.co
     environment:
       TWILIO_NUMBER: "+14382996828"


### PR DESCRIPTION
## Description
This will fix Safari CORS problem with cookie because covidflow is
hosted on dialoguecorp.com and chloe on dialogue.co.

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
https://github.com/dialoguemd/covidflow/pull/226#issue-417975901
## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->