### PR TITLE
feat: send end_of_conversation message (#225)

### DIFF
--- a/action-server/covidflow/actions/action_goodbye.py
+++ b/action-server/covidflow/actions/action_goodbye.py
@@ -4,6 +4,7 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ConversationPaused
 from rasa_sdk.executor import CollectingDispatcher
 
+from .constants import END_CONVERSATION_MESSAGE
 from .lib.log_util import bind_logger
 
 ACTION_NAME = "action_goodbye"
@@ -21,5 +22,7 @@ class ActionGoodbye(Action):
     ) -> List[Dict[Text, Any]]:
         bind_logger(tracker)
         dispatcher.utter_message(template="utter_goodbye")
+
+        dispatcher.utter_message(json_message=END_CONVERSATION_MESSAGE)
 
         return [ConversationPaused()]

--- a/action-server/covidflow/actions/action_qa_goodbye.py
+++ b/action-server/covidflow/actions/action_qa_goodbye.py
@@ -4,7 +4,7 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ConversationPaused
 from rasa_sdk.executor import CollectingDispatcher
 
-from .constants import CANCEL_CI_SLOT
+from .constants import CANCEL_CI_SLOT, END_CONVERSATION_MESSAGE
 from .lib.log_util import bind_logger
 
 
@@ -25,5 +25,7 @@ class ActionQaGoodbye(Action):
             )
 
         dispatcher.utter_message(template="utter_goodbye")
+
+        dispatcher.utter_message(json_message=END_CONVERSATION_MESSAGE)
 
         return [ConversationPaused()]

--- a/action-server/covidflow/actions/action_severe_symptoms_recommendations.py
+++ b/action-server/covidflow/actions/action_severe_symptoms_recommendations.py
@@ -4,6 +4,7 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ConversationPaused
 from rasa_sdk.executor import CollectingDispatcher
 
+from .constants import END_CONVERSATION_MESSAGE
 from .lib.log_util import bind_logger
 
 
@@ -19,5 +20,7 @@ class ActionSevereSymptomsRecommendations(Action):
     ) -> List[Dict[Text, Any]]:
         bind_logger(tracker)
         dispatcher.utter_message(template="utter_call_911")
+
+        dispatcher.utter_message(json_message=END_CONVERSATION_MESSAGE)
 
         return [ConversationPaused()]

--- a/action-server/covidflow/actions/constants.py
+++ b/action-server/covidflow/actions/constants.py
@@ -7,6 +7,8 @@ class Symptoms:  # Not using an enum to avoid persisting enum values
 
 PROVINCES_WITH_211 = ["bc", "ab", "sk", "mb", "on", "qc", "ns"]
 
+END_CONVERSATION_MESSAGE = {"data": {"endOfConversation": True}}
+
 # Slots
 
 ## Slots used by DB

--- a/action-server/tests/actions/action_helper.py
+++ b/action-server/tests/actions/action_helper.py
@@ -58,9 +58,15 @@ class ActionTestCase(TestCase):
         )
 
         self.templates = [message["template"] for message in self.dispatcher.messages]
+        self.json_messages = [message["custom"] for message in self.dispatcher.messages]
 
     def assert_events(self, expected_events: List[Dict]) -> None:
         self.assertEqual(self.events, expected_events)
 
+    # If a message does not contain templates, it appears as None in the list
     def assert_templates(self, expected_templates: List[str]) -> None:
         self.assertEqual(self.templates, expected_templates)
+
+    # If a message does not contain a json custom message, it appears as {} in the list
+    def assert_json_messages(self, expected_messages: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.json_messages, expected_messages)

--- a/action-server/tests/actions/test_action_qa_goodbye.py
+++ b/action-server/tests/actions/test_action_qa_goodbye.py
@@ -1,12 +1,12 @@
 from rasa_sdk.events import ConversationPaused
 
 from covidflow.actions.action_qa_goodbye import ActionQaGoodbye
-from covidflow.actions.constants import CANCEL_CI_SLOT
+from covidflow.actions.constants import CANCEL_CI_SLOT, END_CONVERSATION_MESSAGE
 
 from .action_helper import ActionTestCase
 
 
-class ActionGoodbyeTest(ActionTestCase):
+class ActionQAGoodbyeTest(ActionTestCase):
     def setUp(self):
         super().setUp()
         self.action = ActionQaGoodbye()
@@ -18,7 +18,9 @@ class ActionGoodbyeTest(ActionTestCase):
 
         self.assert_events([ConversationPaused()])
 
-        self.assert_templates(["utter_goodbye"])
+        self.assert_templates(["utter_goodbye", None])
+
+        self.assert_json_messages([{}, END_CONVERSATION_MESSAGE])
 
     def test_cancel_ci_false(self):
         tracker = self.create_tracker(slots={CANCEL_CI_SLOT: False})
@@ -28,5 +30,7 @@ class ActionGoodbyeTest(ActionTestCase):
         self.assert_events([ConversationPaused()])
 
         self.assert_templates(
-            ["utter_daily_ci__qa__will_contact_tomorrow", "utter_goodbye"]
+            ["utter_daily_ci__qa__will_contact_tomorrow", "utter_goodbye", None]
         )
+
+        self.assert_json_messages([{}, {}, END_CONVERSATION_MESSAGE])

--- a/action-server/tests/actions/test_action_severe_symptoms_recommendations.py
+++ b/action-server/tests/actions/test_action_severe_symptoms_recommendations.py
@@ -1,23 +1,25 @@
 from rasa_sdk.events import ConversationPaused
 
-from covidflow.actions.action_goodbye import ActionGoodbye
+from covidflow.actions.action_severe_symptoms_recommendations import (
+    ActionSevereSymptomsRecommendations,
+)
 from covidflow.actions.constants import END_CONVERSATION_MESSAGE
 
 from .action_helper import ActionTestCase
 
 
-class ActionGoodbyeTest(ActionTestCase):
+class ActionSevereSymptomsRecommendationsTest(ActionTestCase):
     def setUp(self):
         super().setUp()
-        self.action = ActionGoodbye()
+        self.action = ActionSevereSymptomsRecommendations()
 
-    def test_goodbye(self):
+    def test_recommendations(self):
         tracker = self.create_tracker()
 
         self.run_action(tracker)
 
         self.assert_events([ConversationPaused()])
 
-        self.assert_templates(["utter_goodbye", None])
+        self.assert_templates(["utter_call_911", None])
 
         self.assert_json_messages([{}, END_CONVERSATION_MESSAGE])

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -57,7 +57,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## suspect - mild symptoms no checkin
 * get_assessment
@@ -132,7 +132,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## suspect - no symptoms contact risk no checkin
 * get_assessment
@@ -153,7 +153,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## suspect - no symptoms no contact risk
 * get_assessment
@@ -204,7 +204,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## tested positive - moderate symptoms
 * tested_positive
@@ -224,7 +224,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## tested positive - mild symptoms worse no check-in
 * tested_positive
@@ -282,7 +282,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## tested positive - mild symptoms not worse no check-in
 * tested_positive
@@ -303,7 +303,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## tested positive - mild symptoms not worse
 * tested_positive
@@ -324,7 +324,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 # tested positive - no symptoms tested less than 14 days no check-in
 * tested_positive
@@ -375,7 +375,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 # tested positive - cured
 * tested_positive
@@ -427,7 +427,7 @@
 * affirm
   - utter_contact_healthcare_professional
   - utter_contact_healthcare_professional_options
-  - utter_goodbye
+  - action_goodbye
 
 ## return for check-in - moderate symptoms - with check-in
 * checkin_return
@@ -480,7 +480,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## return for check-in - mild symptoms - with check-in
 * checkin_return
@@ -499,7 +499,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## return for check-in - mild symptoms - no check-in
 * checkin_return
@@ -540,7 +540,7 @@
   - utter_social_distancing_leave_home
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## return for check-in - no symptoms - first symptoms < 14 days ago
 * checkin_return
@@ -639,7 +639,7 @@
   - action_daily_ci_early_opt_out
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - early opt out - QA
 * daily_checkin{"metadata":{}}
@@ -750,7 +750,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - feel no change - moderate symptoms
 * daily_checkin{"metadata":{}}
@@ -771,7 +771,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - feel no change - mild symptoms
 * daily_checkin{"metadata":{}}
@@ -827,7 +827,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - feel better - moderate symptoms
 * daily_checkin{"metadata":{}}
@@ -848,7 +848,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - feel better - mild symptoms
 * daily_checkin{"metadata":{}}
@@ -869,7 +869,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * done
-  - utter_goodbye
+  - action_goodbye
 
 ## daily check-in - feel better - no symptoms
 * daily_checkin{"metadata":{}}

--- a/integration-tests-en/config.ini
+++ b/integration-tests-en/config.ini
@@ -1,5 +1,5 @@
 [runner]
-ignored_result_keys = sender,recipient_id
+ignored_result_keys = sender,recipient_id,custom
 
 [protocol]
 type = rest


### PR DESCRIPTION
## Description

Send custom json payload to bot. Appears to the bot as {endOfConversation: true} to the bot code.
Had to ignore "custom" field in integration tests because the "true" in the actual output is converted to the True atom, but not in the expected output. 

## Related issues

closes #225 
Relates to #159 and #179

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
