### PR TITLE
fix: test profiles province (#236)

### DIFF
--- a/action-server/alembic/versions/00003_fix_test_profiles.py
+++ b/action-server/alembic/versions/00003_fix_test_profiles.py
@@ -1,0 +1,64 @@
+"""Fix test profiles.
+
+Revision ID: 00003
+Revises:
+Create Date: 2020-05-14
+
+"""
+
+import structlog
+
+from alembic import op
+
+log = structlog.get_logger()
+
+revision = "00003"
+down_revision = "00002"
+branch_labels = None
+depends_on = None
+
+REMINDER_TABLE = "reminder"
+ASSESSMENT_TABLE = "assessment"
+
+OLD_TEST_PROFILE_REVISION = "rev_00002"
+NEW_TEST_PROFILE_REVISION = "rev_00003"
+
+
+def upgrade():
+    op.execute(
+        (
+            f"update reminder set attributes = attributes"
+            f"   || jsonb_build_object('province', substring(attributes->>'province' from 4))"
+            f"   || jsonb_build_object('test_profile', '{NEW_TEST_PROFILE_REVISION}')"
+            f" where attributes->>'test_profile' = '{OLD_TEST_PROFILE_REVISION}'"
+        )
+    )
+
+    op.execute(
+        (
+            f"update assessment set attributes = attributes"
+            f"   || jsonb_build_object('test_profile', '{NEW_TEST_PROFILE_REVISION}')"
+            f" where attributes->>'test_profile' = '{OLD_TEST_PROFILE_REVISION}'"
+        )
+    )
+
+
+def downgrade():
+    log.info("Removing test profiles from reminder table.")
+
+    op.execute(
+        (
+            f"update reminder set attributes = attributes"
+            f"   || jsonb_build_object('province', concat('ca-', attributes->>'province'))"
+            f"   || jsonb_build_object('test_profile', '{OLD_TEST_PROFILE_REVISION}')"
+            f" where attributes->>'test_profile' = '{NEW_TEST_PROFILE_REVISION}'"
+        )
+    )
+
+    op.execute(
+        (
+            f"update assessment set attributes = attributes"
+            f"   || jsonb_build_object('test_profile', '{OLD_TEST_PROFILE_REVISION}')"
+            f" where attributes->>'test_profile' = '{NEW_TEST_PROFILE_REVISION}'"
+        )
+    )


### PR DESCRIPTION
## Description
Fixed test profiles to remove `ca-` from provinces

Migration result:
```
chloe=# select * from reminder ;
 id |          created_at           | last_reminded_at |    timezone     | is_canceled |                                                                                          attributes                                                                                           
----+-------------------------------+------------------+-----------------+-------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "en", "province": "on", "first_name": "Mike", "age_over_65": false, "has_dialogue": false, "phone_number": "15145551234", "test_profile": "rev_00003", "preconditions": false}
  2 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "en", "province": "ab", "first_name": "Kim", "age_over_65": false, "has_dialogue": true, "phone_number": "15145552345", "test_profile": "rev_00003", "preconditions": true}
  3 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "fr", "province": "nt", "first_name": "Maurice", "age_over_65": true, "has_dialogue": false, "phone_number": "15145553456", "test_profile": "rev_00003", "preconditions": false}
  4 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "fr", "province": "qc", "first_name": "Jane", "age_over_65": true, "has_dialogue": true, "phone_number": "15145554567", "test_profile": "rev_00003", "preconditions": true}
(4 rows)

chloe=# select * from assessment ;
 id | reminder_id |         completed_at          |                                                                  attributes                                                                   
----+-------------+-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
  1 |           1 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "mild", "has_cough": false, "has_fever": false, "feel_worse": false, "test_profile": "rev_00003", "has_diff_breathing": false}
  2 |           2 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "moderate", "has_cough": true, "has_fever": true, "feel_worse": false, "test_profile": "rev_00003", "has_diff_breathing": false}
  3 |           3 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "mild", "has_cough": false, "has_fever": false, "feel_worse": false, "test_profile": "rev_00003", "has_diff_breathing": true}
  4 |           4 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "moderate", "has_cough": true, "has_fever": true, "feel_worse": false, "test_profile": "rev_00003", "has_diff_breathing": true}
(4 rows)
```

Downgrade result:

```
chloe=# select * from reminder ;
 id |          created_at           | last_reminded_at |    timezone     | is_canceled |                                                                                            attributes                                                                                            
----+-------------------------------+------------------+-----------------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "en", "province": "ca-on", "first_name": "Mike", "age_over_65": false, "has_dialogue": false, "phone_number": "15145551234", "test_profile": "rev_00002", "preconditions": false}
  2 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "en", "province": "ca-ab", "first_name": "Kim", "age_over_65": false, "has_dialogue": true, "phone_number": "15145552345", "test_profile": "rev_00002", "preconditions": true}
  3 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "fr", "province": "ca-nt", "first_name": "Maurice", "age_over_65": true, "has_dialogue": false, "phone_number": "15145553456", "test_profile": "rev_00002", "preconditions": false}
  4 | 2020-05-14 18:36:43.094815+00 |                  | America/Toronto | f           | {"language": "fr", "province": "ca-qc", "first_name": "Jane", "age_over_65": true, "has_dialogue": true, "phone_number": "15145554567", "test_profile": "rev_00002", "preconditions": true}
(4 rows)

chloe=# select * from assessment ;
 id | reminder_id |         completed_at          |                                                                  attributes                                                                   
----+-------------+-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------
  1 |           1 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "mild", "has_cough": false, "has_fever": false, "feel_worse": false, "test_profile": "rev_00002", "has_diff_breathing": false}
  2 |           2 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "moderate", "has_cough": true, "has_fever": true, "feel_worse": false, "test_profile": "rev_00002", "has_diff_breathing": false}
  3 |           3 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "mild", "has_cough": false, "has_fever": false, "feel_worse": false, "test_profile": "rev_00002", "has_diff_breathing": true}
  4 |           4 | 2020-05-14 18:36:43.094815+00 | {"symptoms": "moderate", "has_cough": true, "has_fever": true, "feel_worse": false, "test_profile": "rev_00002", "has_diff_breathing": true}
(4 rows)
```

## Related issues

closes #236 
closes #233 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
