### PR TITLE
fix(flow): 11-length phone numbers to start with 1 (#241)

### DIFF
--- a/action-server/covidflow/actions/daily_ci_enroll_form.py
+++ b/action-server/covidflow/actions/daily_ci_enroll_form.py
@@ -371,7 +371,7 @@ def _get_first_name(text: Text) -> Optional[Text]:
 
 def _get_phone_number(text: Text) -> Optional[Text]:
     digits = NOT_DIGIT_REGEX.sub("", text)
-    if len(digits) == 11:
+    if len(digits) == 11 and digits[0] == "1":
         return digits
     if len(digits) == 10:
         return f"1{digits}"

--- a/action-server/tests/actions/test_daily_ci_enroll_form.py
+++ b/action-server/tests/actions/test_daily_ci_enroll_form.py
@@ -83,6 +83,7 @@ class TestDailyCiEnrollForm(FormTestCase):
         await self._validate_phone_number("it's 1 514 555 4567", "15145554567")
 
         await self._validate_phone_number("145554567", None)
+        await self._validate_phone_number("25145554567", None)
 
     async def _validate_phone_number(self, text: str, expected_phone_number: str):
         tracker = self.create_tracker(


### PR DESCRIPTION
## Description

Super-simple validation just got a little less simple. A phone number with length of 11 has to start with a 1 (Canada and US country code)

## Related issues

closes #241

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
