### PR TITLE
fix: missing message in fever only flow (#210)

### DIFF
--- a/action-server/covidflow/actions/assessment_form.py
+++ b/action-server/covidflow/actions/assessment_form.py
@@ -96,7 +96,7 @@ class AssessmentForm(FormAction):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> Dict[Text, Any]:
-        if value is True:
+        if value is True or tracker.get_slot(HAS_FEVER_SLOT) is True:
             dispatcher.utter_message(template="utter_mild_symptoms_self_isolate")
 
         return {HAS_COUGH_SLOT: value}

--- a/action-server/tests/actions/test_assessment_form.py
+++ b/action-server/tests/actions/test_assessment_form.py
@@ -347,6 +347,30 @@ class TestAssessmentForm(FormTestCase):
             ["utter_mild_symptoms_self_isolate", "utter_ask_lives_alone"]
         )
 
+    def test_fever_mild_symptoms_no_cough(self):
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: HAS_COUGH_SLOT,
+                SEVERE_SYMPTOMS_SLOT: False,
+                PROVINCE_SLOT: "qc",
+                PROVINCIAL_811_SLOT: "811 qc",
+                AGE_OVER_65_SLOT: False,
+                HAS_FEVER_SLOT: True,
+                MODERATE_SYMPTOMS_SLOT: False,
+            },
+            intent="deny",
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [SlotSet(HAS_COUGH_SLOT, False), SlotSet(REQUESTED_SLOT, LIVES_ALONE_SLOT),]
+        )
+
+        self.assert_templates(
+            ["utter_mild_symptoms_self_isolate", "utter_ask_lives_alone"]
+        )
+
     def test_fever_cough_lives_alone(self):
         self._test_mild_symptoms_lives_alone(fever=True, cough=True)
 


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/5585923/82064145-61e8d400-969a-11ea-8d51-bb46cd58901c.png)


## Related issues

closes #210 


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
