### PR TITLE
fix(flow): question answering intro messages

### DIFF
--- a/action-server/tests/actions/action_helper.py
+++ b/action-server/tests/actions/action_helper.py
@@ -59,6 +59,7 @@ class ActionTestCase(TestCase):
 
         self.templates = [message["template"] for message in self.dispatcher.messages]
         self.json_messages = [message["custom"] for message in self.dispatcher.messages]
+        self.texts = [message["text"] for message in self.dispatcher.messages]
 
     def assert_events(self, expected_events: List[Dict]) -> None:
         self.assertEqual(self.events, expected_events)
@@ -70,3 +71,7 @@ class ActionTestCase(TestCase):
     # If a message does not contain a json custom message, it appears as {} in the list
     def assert_json_messages(self, expected_messages: List[Dict[str, Any]]) -> None:
         self.assertEqual(self.json_messages, expected_messages)
+
+    # If a message does not contain a text message, it appears as None in the list
+    def assert_texts(self, expected_texts: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.texts, expected_texts)

--- a/action-server/tests/actions/form_helper.py
+++ b/action-server/tests/actions/form_helper.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, List
+from typing import Any, Dict, List
 from unittest import TestCase
 
 from rasa_sdk import Tracker
@@ -65,9 +65,20 @@ class FormTestCase(TestCase):
         )
 
         self.templates = [message["template"] for message in self.dispatcher.messages]
+        self.json_messages = [message["custom"] for message in self.dispatcher.messages]
+        self.texts = [message["text"] for message in self.dispatcher.messages]
 
     def assert_events(self, expected_events: List[Dict]) -> None:
         self.assertEqual(self.events, expected_events)
 
+    # If a message does not contain templates, it appears as None in the list
     def assert_templates(self, expected_templates: List[str]) -> None:
         self.assertEqual(self.templates, expected_templates)
+
+    # If a message does not contain a json custom message, it appears as {} in the list
+    def assert_json_messages(self, expected_messages: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.json_messages, expected_messages)
+
+    # If a message does not contain a text message, it appears as None in the list
+    def assert_texts(self, expected_texts: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.texts, expected_texts)

--- a/action-server/tests/actions/test_question_answering_form.py
+++ b/action-server/tests/actions/test_question_answering_form.py
@@ -1,0 +1,230 @@
+from unittest.mock import MagicMock, patch
+
+from rasa_sdk.events import Form, SlotSet
+from rasa_sdk.forms import REQUESTED_SLOT
+
+from covidflow.actions.answers import QuestionAnsweringResponse, QuestionAnsweringStatus
+from covidflow.actions.question_answering_form import (
+    ANSWERS_KEY,
+    ANSWERS_SLOT,
+    ASKED_QUESTION_SLOT,
+    FEEDBACK_KEY,
+    FEEDBACK_SLOT,
+    FORM_NAME,
+    QUESTION_KEY,
+    QUESTION_SLOT,
+    STATUS_KEY,
+    STATUS_SLOT,
+    QuestionAnsweringForm,
+)
+
+from .form_helper import FormTestCase
+
+
+def QuestionAnsweringResponseMock(*args, **kwargs):
+    mock = MagicMock(*args, **kwargs)
+
+    async def mock_coroutine(*args, **kwargs):
+        return mock(*args, **kwargs)
+
+    mock_coroutine.mock = mock
+    return mock_coroutine
+
+
+QUESTION = "What is covid?"
+ANSWERS = [
+    "It's a virus!",
+    "It's the greatest plea since the plague!",
+    "No, it's SU-PER BAD!",
+]
+
+SUCCESS_RESULT = QuestionAnsweringResponse(
+    answers=ANSWERS, status=QuestionAnsweringStatus.SUCCESS
+)
+FAILURE_RESULT = QuestionAnsweringResponse(status=QuestionAnsweringStatus.FAILURE)
+OUT_OF_DISTRIBUTION_RESULT = QuestionAnsweringResponse(
+    status=QuestionAnsweringStatus.OUT_OF_DISTRIBUTION
+)
+
+
+FULL_RESULT_SUCCESS = {
+    QUESTION_KEY: QUESTION,
+    ANSWERS_KEY: ANSWERS,
+    STATUS_KEY: QuestionAnsweringStatus.SUCCESS,
+    FEEDBACK_KEY: True,
+}
+
+
+class TestQuestionAnsweringForm(FormTestCase):
+    def setUp(self):
+        super().setUp()
+        self.form = QuestionAnsweringForm()
+
+    def test_form_activation_first_time(self):
+        tracker = self.create_tracker(active_form=False)
+
+        self.run_form(tracker)
+
+        self.assert_events([Form(FORM_NAME), SlotSet(REQUESTED_SLOT, QUESTION_SLOT)])
+
+        self.assert_templates(
+            [
+                "utter_can_help_with_questions",
+                "utter_qa_disclaimer",
+                "utter_ask_active_question",
+            ]
+        )
+
+    def test_form_activation_not_first_time(self):
+        tracker = self.create_tracker(
+            slots={ASKED_QUESTION_SLOT: FULL_RESULT_SUCCESS}, active_form=False
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events([Form(FORM_NAME), SlotSet(REQUESTED_SLOT, QUESTION_SLOT)])
+
+        self.assert_templates(["utter_ask_active_question"])
+
+    @patch("covidflow.actions.question_answering_form.QuestionAnsweringProtocol")
+    def test_provide_question_success(self, mock_protocol):
+        mock_protocol.return_value.get_response = QuestionAnsweringResponseMock(
+            return_value=SUCCESS_RESULT
+        )
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: QUESTION_SLOT}, text=QUESTION
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(QUESTION_SLOT, QUESTION),
+                SlotSet(STATUS_SLOT, QuestionAnsweringStatus.SUCCESS),
+                SlotSet(ANSWERS_SLOT, ANSWERS),
+                SlotSet(REQUESTED_SLOT, FEEDBACK_SLOT),
+            ]
+        )
+
+        self.assert_templates([None, "utter_ask_feedback"])
+
+        self.assert_texts([ANSWERS[0], None])
+
+    @patch("covidflow.actions.question_answering_form.QuestionAnsweringProtocol")
+    def test_provide_question_failure(self, mock_protocol):
+        mock_protocol.return_value.get_response = QuestionAnsweringResponseMock(
+            return_value=FAILURE_RESULT
+        )
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: QUESTION_SLOT}, text=QUESTION
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(QUESTION_SLOT, QUESTION),
+                SlotSet(STATUS_SLOT, QuestionAnsweringStatus.FAILURE),
+                SlotSet(ANSWERS_SLOT, None),
+                SlotSet(QUESTION_SLOT, None),
+                SlotSet(FEEDBACK_SLOT, None),
+                SlotSet(
+                    ASKED_QUESTION_SLOT,
+                    {
+                        QUESTION_KEY: QUESTION,
+                        STATUS_KEY: QuestionAnsweringStatus.FAILURE,
+                        ANSWERS_KEY: None,
+                        FEEDBACK_KEY: None,
+                    },
+                ),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates([])
+
+    @patch("covidflow.actions.question_answering_form.QuestionAnsweringProtocol")
+    def test_provide_question_out_of_distribution(self, mock_protocol):
+        mock_protocol.return_value.get_response = QuestionAnsweringResponseMock(
+            return_value=OUT_OF_DISTRIBUTION_RESULT
+        )
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: QUESTION_SLOT}, text=QUESTION
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(QUESTION_SLOT, None),
+                SlotSet(
+                    ASKED_QUESTION_SLOT,
+                    {
+                        QUESTION_KEY: QUESTION,
+                        STATUS_KEY: QuestionAnsweringStatus.OUT_OF_DISTRIBUTION,
+                    },
+                ),
+                SlotSet(STATUS_SLOT, None),
+                SlotSet(REQUESTED_SLOT, QUESTION_SLOT),
+            ]
+        )
+
+        self.assert_templates(["utter_cant_answer", "utter_ask_active_question"])
+
+    def test_provide_feedback_affirm(self):
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: FEEDBACK_SLOT,
+                QUESTION_SLOT: QUESTION,
+                ANSWERS_SLOT: ANSWERS,
+                STATUS_SLOT: QuestionAnsweringStatus.SUCCESS,
+            },
+            intent="affirm",
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(FEEDBACK_SLOT, True),
+                SlotSet(QUESTION_SLOT, None),
+                SlotSet(FEEDBACK_SLOT, None),
+                SlotSet(ASKED_QUESTION_SLOT, FULL_RESULT_SUCCESS),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates([])
+
+    def test_provide_feedback_deny(self):
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: FEEDBACK_SLOT,
+                QUESTION_SLOT: QUESTION,
+                ANSWERS_SLOT: ANSWERS,
+                STATUS_SLOT: QuestionAnsweringStatus.SUCCESS,
+            },
+            intent="deny",
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(FEEDBACK_SLOT, False),
+                SlotSet(QUESTION_SLOT, None),
+                SlotSet(FEEDBACK_SLOT, None),
+                SlotSet(
+                    ASKED_QUESTION_SLOT, {**FULL_RESULT_SUCCESS, FEEDBACK_KEY: False}
+                ),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(["utter_post_feedback"])

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -30,7 +30,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -77,7 +77,6 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -104,7 +103,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -166,7 +165,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -246,7 +245,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -346,7 +345,7 @@
   - action_visit_package
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -390,7 +389,7 @@
   - action_tested_positive_maybe_cured_final_recommendations
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -433,7 +432,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -499,7 +498,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -536,7 +535,7 @@
   - utter_self_isolate_symptom_free
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -550,7 +549,7 @@
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -566,7 +565,7 @@
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -580,7 +579,7 @@
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -600,7 +599,7 @@
   - utter_greet
   - utter_ask_how_may_i_help
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -674,7 +673,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -702,7 +701,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -779,7 +778,7 @@
   - slot{"question_answering_status": "success"}
   - utter_ask_another_question
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
@@ -871,7 +870,7 @@
   - form{"name": null}
   - utter_ask_anything_else
 * ask_question
-  - utter_can_help_with_questions
+
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -392,6 +392,9 @@ responses:
   utter_can_help_with_questions:
     - text: "I can help answer your questions about Covid-19, on many different topics"
 
+  utter_qa_disclaimer:
+    - text: "Please note that at the moment, I can provide answers to a limited number of questions, but I'm constantly improving and learning from the questions you ask me"
+
   utter_ask_active_question:
     - text: "Please write your question about Covid-19:"
 

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -392,6 +392,9 @@ responses:
   utter_can_help_with_questions:
     - text: "Je peux répondre à vos questions sur une variété de sujets entourant la Covid-19"
 
+  utter_qa_disclaimer:
+    - text: "Veuillez noter que pour le moment, je suis en mesure de répondre à un nombre limité de questions, mais je m'améliore constamment et j'apprends à l'aide des questions que vous me posez"
+
   utter_ask_active_question:
     - text: "Veuillez écrire votre question au sujet de la Covid-19:"
 


### PR DESCRIPTION
## Description

Added disclaimer message and corrected appearance of intro message since both would appear at the same time and adding the second message in stories would just have broken things more. Both messages are now in the form, played only for the first question of the conversation.

## Related issues

closes #247, closes #202, closes #239 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
