### PR TITLE
fix(flow): out of distribution loop (#280)

### DIFF
--- a/action-server/covidflow/actions/question_answering_form.py
+++ b/action-server/covidflow/actions/question_answering_form.py
@@ -95,17 +95,7 @@ class QuestionAnsweringForm(FormAction):
             )
 
             if result.status == QuestionAnsweringStatus.OUT_OF_DISTRIBUTION:
-                full_result = {
-                    QUESTION_KEY: value,
-                    STATUS_KEY: result.status,
-                }
                 dispatcher.utter_message(template="utter_cant_answer")
-
-                return {
-                    ASKED_QUESTION_SLOT: full_result,
-                    QUESTION_SLOT: None,
-                    STATUS_SLOT: None,
-                }
 
             if result.status == QuestionAnsweringStatus.SUCCESS and result.answers:
                 dispatcher.utter_message(result.answers[0])

--- a/action-server/tests/actions/test_question_answering_form.py
+++ b/action-server/tests/actions/test_question_answering_form.py
@@ -160,20 +160,26 @@ class TestQuestionAnsweringForm(FormTestCase):
 
         self.assert_events(
             [
+                SlotSet(QUESTION_SLOT, QUESTION),
+                SlotSet(STATUS_SLOT, QuestionAnsweringStatus.OUT_OF_DISTRIBUTION),
+                SlotSet(ANSWERS_SLOT, None),
                 SlotSet(QUESTION_SLOT, None),
+                SlotSet(FEEDBACK_SLOT, None),
                 SlotSet(
                     ASKED_QUESTION_SLOT,
                     {
                         QUESTION_KEY: QUESTION,
                         STATUS_KEY: QuestionAnsweringStatus.OUT_OF_DISTRIBUTION,
+                        ANSWERS_KEY: None,
+                        FEEDBACK_KEY: None,
                     },
                 ),
-                SlotSet(STATUS_SLOT, None),
-                SlotSet(REQUESTED_SLOT, QUESTION_SLOT),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
             ]
         )
 
-        self.assert_templates(["utter_cant_answer", "utter_ask_active_question"])
+        self.assert_templates(["utter_cant_answer"])
 
     def test_provide_feedback_affirm(self):
         tracker = self.create_tracker(

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -32,8 +32,8 @@
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
-  - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * done
   - action_qa_goodbye
 
@@ -101,14 +101,7 @@
   - action_suspect_mild_symptoms_exposure_final_recommendations
   - action_visit_package
   - utter_ask_anything_else
-* ask_question
-  - question_answering_form
-  - form{"name": "question_answering_form"}
-  - form{"name": null}
-  - slot{"question_answering_status": "failure"}
-  - utter_question_answering_error
-  - utter_try_again_later
-  - action_qa_goodbye
+* done
   - action_goodbye
 
 ## suspect - no symptoms contact risk
@@ -148,7 +141,7 @@
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - utter_please_visit_again
   - action_qa_goodbye
@@ -179,8 +172,15 @@
   - form{"name": null}
   - action_visit_package
   - utter_ask_anything_else
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * done
-  - action_goodbye
+  - utter_please_visit_again
+  - action_qa_goodbye
 
 ## tested positive - moderate symptoms
 * tested_positive
@@ -227,13 +227,13 @@
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * ask_question
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
-  - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * done
   - action_qa_goodbye
 
@@ -277,8 +277,14 @@
   - form{"name": null}
   - action_visit_package
   - utter_ask_anything_else
-* done
-  - action_goodbye
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - action_qa_goodbye
 
 ## tested positive - mild symptoms not worse
 * tested_positive
@@ -368,14 +374,14 @@
   - form{"name": "question_answering_form"}
   - form{"name": null}
   - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - utter_ask_other_questions_after_answer
 * ask_question
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - utter_please_visit_again
   - action_qa_goodbye
@@ -411,7 +417,7 @@
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - utter_please_visit_again
   - action_qa_goodbye
@@ -475,7 +481,7 @@
   - form{"name": "question_answering_form"}
   - form{"name": null}
   - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - utter_ask_other_questions_after_answer
 * done
   - action_qa_goodbye
 
@@ -541,6 +547,18 @@
 * done
   - action_qa_goodbye
 
+# QA - out of distribution
+* greet{"metadata":{}}
+  - action_greeting_messages
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_no_assessment
+* done
+  - action_qa_goodbye
+
 ## QA - success - another question
 * greet{"metadata":{}}
   - action_greeting_messages
@@ -559,7 +577,25 @@
 * done
   - action_qa_goodbye
 
-## QA - need_assessment - no assessment after
+# QA - out of distribution - another question
+* greet{"metadata":{}}
+  - action_greeting_messages
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_no_assessment
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_no_assessment
+* done
+  - action_qa_goodbye
+
+## QA - need assessment - no assessment after
 * greet{"metadata":{}}
   - action_greeting_messages
 * ask_question
@@ -640,7 +676,7 @@
   - form{"name": "question_answering_form"}
   - form{"name": null}
   - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - utter_ask_other_questions_after_answer
 * done
   - action_qa_goodbye
 
@@ -668,7 +704,7 @@
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - action_qa_goodbye
 
@@ -690,8 +726,15 @@
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * done
-  - action_goodbye
+  - utter_please_visit_again
+  - action_qa_goodbye
 
 ## daily check-in - feel no change - moderate symptoms
 * daily_checkin{"metadata":{}}
@@ -736,15 +779,15 @@
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
-  - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * ask_question
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - action_qa_goodbye
 
@@ -766,8 +809,15 @@
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_assessment_done
 * done
-  - action_goodbye
+  - utter_please_visit_again
+  - action_qa_goodbye
 
 ## daily check-in - feel better - moderate symptoms
 * daily_checkin{"metadata":{}}
@@ -787,8 +837,14 @@
   - form{"name": "daily_ci_keep_or_cancel_form"}
   - form{"name": null}
   - utter_ask_anything_else
-* done
-  - action_goodbye
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
+  - action_qa_goodbye
 
 ## daily check-in - feel better - mild symptoms
 * daily_checkin{"metadata":{}}
@@ -883,8 +939,15 @@
   - action_suspect_moderate_symptoms_final_recommendations
   - action_visit_package
   - utter_ask_anything_else
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "success"}
+  - utter_ask_other_questions_after_answer
 * done
-  - action_goodbye
+  - utter_please_visit_again
+  - action_qa_goodbye
 
 ## daily check-in - invalid ID - wants assessment - mild symptoms
 * daily_checkin{"metadata":{}}
@@ -930,7 +993,7 @@
   - form{"name": null}
   - slot{"question_answering_status": "need_assessment"}
   - utter_need_assessment_already_done
-  - utter_ask_another_question
+  - utter_ask_another_question_assessment_done
 * done
   - utter_please_visit_again
   - action_qa_goodbye
@@ -996,10 +1059,11 @@
   - form{"name": null}
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
+* deny
   - utter_try_again_later
   - action_qa_goodbye
 
-## daily check-in - invalid ID - ask question - success two questions
+## daily check-in - invalid ID - ask question - ood two questions
 * daily_checkin{"metadata":{}}
   - action_initialize_daily_checkin
   - slot{"invalid_reminder_id": true}
@@ -1010,15 +1074,15 @@
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
-  - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_ask_another_question_no_assessment
 * ask_question
   - question_answering_form
   - form{"name": "question_answering_form"}
   - form{"name": null}
-  - slot{"question_answering_status": "success"}
-  - utter_ask_another_question
-* done
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_try_again_later
   - action_qa_goodbye
 
 ## daily check-in - invalid ID - ask question - need assessment

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -475,7 +475,7 @@ responses:
     - text: "Please try again later if you have questions"
 
   utter_cant_answer:
-    - text: "I’m sorry, I can’t answer your question, please try again"
+    - text: "I’m sorry, I can’t answer your question"
 
   utter_need_assessment:
     - text: "It seems like you need help with your symptoms"
@@ -504,11 +504,29 @@ responses:
         - title: "I'm done"
           payload: "/done"
 
-  utter_ask_another_question:
+  utter_ask_other_questions_after_answer:
+    - text: "Do you have another question?"
+      buttons:
+        - title: Yes
+          payload: "/ask_question"
+        - title: "No I'm done"
+          payload: "/done"
+
+  utter_ask_another_question_assessment_done:
     - text: "Would you like to ask another question?"
       buttons:
         - title: Yes
           payload: "/ask_question"
+        - title: "No I'm done"
+          payload: "/done"
+
+  utter_ask_another_question_no_assessment:
+    - text: "Would you like to ask another question?"
+      buttons:
+        - title: Yes
+          payload: "/ask_question"
+        - title: No get self-assessment
+          payload: "/get_assessment"
         - title: "No I'm done"
           payload: "/done"
 

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -475,7 +475,7 @@ responses:
     - text: "Veuillez essayer de poser vos questions un peu plus tard"
 
   utter_cant_answer:
-    - text: "Je suis désolée, je ne peux pas répondre à votre question. Veuillez essayer de nouveau"
+    - text: "Je suis désolée, je ne peux pas répondre à votre question"
 
   utter_need_assessment:
     - text: "Il semble que vous ayez besoin d’aide pour évaluer vos symptômes"
@@ -504,11 +504,29 @@ responses:
         - title: "J'ai terminé"
           payload: "/done"
 
-  utter_ask_another_question:
+  utter_ask_other_questions_after_answer:
+    - text: "Avez-vous d'autres questions?"
+      buttons:
+        - title: Oui
+          payload: "/ask_question"
+        - title: "Non j'ai terminé"
+          payload: "/done"
+
+  utter_ask_another_question_assessment_done:
     - text: "Aimeriez-vous poser une autre question?"
       buttons:
         - title: Oui
           payload: "/ask_question"
+        - title: "Non j'ai terminé"
+          payload: "/done"
+
+  utter_ask_another_question_no_assessment:
+    - text: "Aimeriez-vous poser une autre question?"
+      buttons:
+        - title: Oui
+          payload: "/ask_question"
+        - title: Non évaluer mes symptômes
+          payload: /get_assessment
         - title: "Non j'ai terminé"
           payload: "/done"
 


### PR DESCRIPTION
## Description

Out_of_distribution status now leads outside the form and to ask what to do next instead of re-asking for the question. 

I had to redistribute the stories with questions after assessments to make sure there was no apparent link between the actions after the form and the symptoms slot to have better prediction scores (had some as low as 0.41, even though the question was the good one, before that. It got up to always better than 0.7, in the cases I could try).

This methid remains fragile and is obviously not ideal.

## Related issues

closes #280

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
