### PR TITLE
feat(flow): get test locations flow (#282)

### DIFF
--- a/action-server/covidflow/actions/constants.py
+++ b/action-server/covidflow/actions/constants.py
@@ -57,3 +57,4 @@ HAS_CONTACT_RISK_SLOT = "has_contact_risk"
 
 # Shared with stories
 INVALID_REMINDER_ID_SLOT = "invalid_reminder_id"
+TEST_NAVIGATION_SUCCESS_SLOT = "test_navigation_success"

--- a/action-server/covidflow/actions/test_navigation_form.py
+++ b/action-server/covidflow/actions/test_navigation_form.py
@@ -1,0 +1,245 @@
+import re
+from typing import Any, Dict, List, Optional, Text, Union
+
+import structlog
+from rasa_sdk import Tracker
+from rasa_sdk.events import SlotSet
+from rasa_sdk.executor import CollectingDispatcher
+from rasa_sdk.forms import FormAction
+
+from covidflow.utils.geocoding import Geocoding
+from covidflow.utils.maps import get_map_url
+from covidflow.utils.testing_locations import (
+    TestingLocation,
+    TestingLocationPhone,
+    get_testing_locations,
+)
+
+from .constants import LANGUAGE_SLOT, TEST_NAVIGATION_SUCCESS_SLOT
+from .lib.log_util import bind_logger
+
+logger = structlog.get_logger()
+
+FORM_NAME = "test_navigation_form"
+
+
+POSTAL_CODE_REGEX = re.compile(r"[a-z]\d[a-z] ?\d[a-z]\d", re.IGNORECASE)
+MAX_POSTAL_CODE_TRIES = 2
+
+POSTAL_CODE_SLOT = "test_navigation__postal_code"
+INVALID_POSTAL_CODE_COUNTER_SLOT = "test_navigation__invalid_postal_code_counter"
+TRY_DIFFERENT_ADDRESS_SLOT = "test_navigation__try_different_address"
+LOCATIONS_SLOT = "test_navigation__locations"
+END_FORM_SLOT = "test_navigation__end_form"
+
+
+class TestNavigationForm(FormAction):
+    def __init__(self):
+        self.geocoding_client = Geocoding()
+
+        super().__init__()
+
+    def name(self) -> Text:
+        return FORM_NAME
+
+    async def run(
+        self, dispatcher, tracker, domain,
+    ):
+        bind_logger(tracker)
+        return await super().run(dispatcher, tracker, domain)
+
+    @staticmethod
+    def required_slots(tracker: Tracker) -> List[Text]:
+        if tracker.get_slot(END_FORM_SLOT) is True:
+            return []
+
+        if tracker.get_slot(LOCATIONS_SLOT):
+            return [POSTAL_CODE_SLOT]
+
+        return [POSTAL_CODE_SLOT, TRY_DIFFERENT_ADDRESS_SLOT]
+
+    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
+        return {
+            POSTAL_CODE_SLOT: self.from_text(),
+            TRY_DIFFERENT_ADDRESS_SLOT: [
+                self.from_intent(intent="affirm", value=True),
+                self.from_intent(intent="deny", value=False),
+            ],
+        }
+
+    async def validate_test_navigation__postal_code(
+        self,
+        value: Text,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> Dict[Text, Any]:
+        postal_code = _get_postal_code(value)
+        if postal_code is None:
+            return _check_postal_code_error_counter(tracker, dispatcher)
+
+        try:
+            coordinates = self.geocoding_client.get_from_postal_code(postal_code)
+            if coordinates is None:
+                return _check_postal_code_error_counter(tracker, dispatcher)
+
+            testing_locations = await get_testing_locations(coordinates)
+
+        except:
+            dispatcher.utter_message(
+                template="utter_test_navigation__could_not_fetch_1"
+            )
+            dispatcher.utter_message(
+                template="utter_test_navigation__could_not_fetch_2"
+            )
+            return {POSTAL_CODE_SLOT: postal_code, END_FORM_SLOT: True}
+
+        if len(testing_locations) == 0:
+            dispatcher.utter_message(template="utter_test_navigation__no_locations")
+
+        elif len(testing_locations) == 1:
+            dispatcher.utter_message(template="utter_test_navigation__one_location")
+            dispatcher.utter_message(
+                attachment=_locations_carousel(
+                    tracker.get_slot(LANGUAGE_SLOT), domain, testing_locations
+                )
+            )
+
+        else:
+            dispatcher.utter_message(
+                template="utter_test_navigation__many_locations_1",
+                nb_testing_sites=len(testing_locations),
+            )
+            dispatcher.utter_message(template="utter_test_navigation__many_locations_2")
+            dispatcher.utter_message(template="utter_test_navigation__many_locations_3")
+            dispatcher.utter_message(
+                attachment=_locations_carousel(
+                    tracker.get_slot(LANGUAGE_SLOT), domain, testing_locations
+                )
+            )
+
+        return {
+            POSTAL_CODE_SLOT: postal_code,
+            LOCATIONS_SLOT: [location.raw_data for location in testing_locations],
+        }
+
+    def validate_test_navigation__try_different_address(
+        self,
+        value: bool,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> Dict[Text, Any]:
+
+        if value:
+            return {POSTAL_CODE_SLOT: None, LOCATIONS_SLOT: None}
+
+        dispatcher.utter_message(template="utter_test_navigation__acknowledge")
+        return {}
+
+    def submit(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: Dict[Text, Any],
+    ) -> List[Dict]:
+        if tracker.get_slot(LOCATIONS_SLOT):
+            success = True
+        else:
+            success = False
+
+        return [SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, success)]
+
+
+def _get_postal_code(text: str) -> Optional[str]:
+    matches = POSTAL_CODE_REGEX.search(text)
+    if matches:
+        return matches.group()
+    return None
+
+
+def _check_postal_code_error_counter(
+    tracker: Tracker, dispatcher: CollectingDispatcher
+) -> Dict[Text, Any]:
+    try_counter = tracker.get_slot(INVALID_POSTAL_CODE_COUNTER_SLOT)
+
+    if try_counter == MAX_POSTAL_CODE_TRIES:
+        dispatcher.utter_message(
+            template="utter_test_navigation__invalid_postal_code_max"
+        )
+        return {POSTAL_CODE_SLOT: None, END_FORM_SLOT: True}
+
+    dispatcher.utter_message(template="utter_test_navigation__invalid_postal_code")
+
+    return {
+        POSTAL_CODE_SLOT: None,
+        INVALID_POSTAL_CODE_COUNTER_SLOT: try_counter + 1,
+    }
+
+
+def _locations_carousel(
+    language: str, domain: Dict[Text, Any], testing_locations: List[TestingLocation]
+) -> Dict[Text, Any]:
+    titles_response = domain.get("responses", {}).get(
+        "utter_test_navigation__display_titles", []
+    )
+
+    titles = titles_response[0].get("custom", {}) if len(titles_response) >= 1 else {}
+    cards = [
+        _generate_location_card(location, titles, language)
+        for location in testing_locations
+    ]
+    return {
+        "type": "template",
+        "payload": {"template_type": "generic", "elements": cards},
+    }
+
+
+def _generate_location_card(
+    location: TestingLocation, titles: Dict[Text, Text], language: str
+) -> Dict[Text, Any]:
+    phone_number = (
+        _format_phone_number(location.phones[0]) if len(location.phones) >= 1 else None
+    )
+    buttons = (
+        [
+            _url_button(
+                f"{titles.get('call_button')}{phone_number['full']}",
+                f"tel:{phone_number['link']}",
+            )
+        ]
+        if phone_number
+        else []
+    )
+    buttons.append(
+        _url_button(
+            titles["directions_button"],
+            f"http://maps.apple.com/?q={location.coordinates[0]},{location.coordinates[1]}",
+        )
+    )
+
+    return {
+        "title": location.name,
+        "subtitle": location.description.get(language, ""),
+        "image_url": get_map_url(location.coordinates),
+        "buttons": buttons,
+    }
+
+
+def _format_phone_number(phone_number: TestingLocationPhone) -> Dict[Text, str]:
+    number = phone_number.number[-10:]  # remove first number if country code is there
+    formatted_number = f"{number[0:3]}-{number[3:6]}-{number[6:10]}"
+    full_number = (
+        f"{formatted_number} ext. {phone_number.extension}"
+        if phone_number.extension
+        else formatted_number
+    )
+    return {"full": full_number, "link": formatted_number}
+
+
+def _url_button(title: str, url: str) -> Dict[Text, Any]:
+    return {
+        "title": title,
+        "type": "web_url",
+        "url": url,
+    }

--- a/action-server/covidflow/utils/geocoding.py
+++ b/action-server/covidflow/utils/geocoding.py
@@ -1,10 +1,12 @@
 import os
-from typing import Optional, Tuple
+from typing import Any, Dict, NamedTuple, Optional
 
 import googlemaps
 import structlog
 
 logger = structlog.get_logger()
+
+DEFAULT_COUNTRY = "CA"
 
 GOOGLE_API_KEY_ENV = "GOOGLE_GEOCODING_API_KEY"
 
@@ -14,25 +16,35 @@ LATITUDE = "lat"
 LONGITUDE = "lng"
 
 
+class Coordinates(NamedTuple):
+    latitude: float
+    longitude: float
+
+
 class Geocoding:
     def __init__(self):
         key = os.environ[GOOGLE_API_KEY_ENV]
         self.client = googlemaps.Client(key=key)
 
-    def get(self, address: str) -> Optional[Tuple[float, float]]:
-        try:
-            geocode_result = self.client.geocode(address)
+    def get_from_address(self, address: str) -> Optional[Coordinates]:
+        request = {"address": address}
+        return self._get_geocode(request)
 
-            if (len(geocode_result)) == 0:
-                return None
+    def get_from_postal_code(self, postal_code: str) -> Optional[Coordinates]:
+        request = {
+            "components": {"postal_code": postal_code, "country": DEFAULT_COUNTRY}
+        }
+        return self._get_geocode(request)
 
-            location = geocode_result[0].get(GEOMETRY, {}).get(LOCATION, {})
+    def _get_geocode(self, request: Dict[str, Any]) -> Optional[Coordinates]:
+        geocode_result = self.client.geocode(**request)
 
-            if LATITUDE not in location or LONGITUDE not in location:
-                return None
-
-            return (location[LATITUDE], location[LONGITUDE])
-
-        except:
-            logger.exception(f"Error occured geocoding address: '{address}'")
+        if (len(geocode_result)) == 0:
             return None
+
+        location = geocode_result[0].get(GEOMETRY, {}).get(LOCATION, {})
+
+        if LATITUDE not in location or LONGITUDE not in location:
+            return None
+
+        return Coordinates(location[LATITUDE], location[LONGITUDE])

--- a/action-server/covidflow/utils/maps.py
+++ b/action-server/covidflow/utils/maps.py
@@ -2,8 +2,9 @@ import base64
 import hashlib
 import hmac
 import os
-from typing import Tuple
 from urllib.parse import urlencode
+
+from .geocoding import Coordinates
 
 GOOGLE_API_KEY_ENV = "GOOGLE_MAPS_API_KEY"
 GOOGLE_SIGN_SECRET_ENV = "GOOGLE_MAPS_URL_SIGN_SECRET"
@@ -12,9 +13,7 @@ MAPS_ENDPOINT = "https://maps.googleapis.com"
 MAPS_API_PATH = "/maps/api/staticmap"
 
 
-def get_map_url(
-    coordinates: Tuple[float, float], size: str = "220x150", zoom: int = 15
-):
+def get_map_url(coordinates: Coordinates, size: str = "220x150", zoom: int = 15):
     key = os.environ[GOOGLE_API_KEY_ENV]
     secret = os.environ[GOOGLE_SIGN_SECRET_ENV]
     parameters = {

--- a/action-server/mypy.ini
+++ b/action-server/mypy.ini
@@ -24,3 +24,6 @@ ignore_missing_imports = True
 [mypy-googlemaps.*]
 ignore_missing_imports = True
 
+[mypy-pytest.*]
+ignore_missing_imports = True
+

--- a/action-server/tests/actions/action_helper.py
+++ b/action-server/tests/actions/action_helper.py
@@ -60,6 +60,9 @@ class ActionTestCase(TestCase):
         self.templates = [message["template"] for message in self.dispatcher.messages]
         self.json_messages = [message["custom"] for message in self.dispatcher.messages]
         self.texts = [message["text"] for message in self.dispatcher.messages]
+        self.attachments = [
+            message["attachment"] for message in self.dispatcher.messages
+        ]
 
     def assert_events(self, expected_events: List[Dict]) -> None:
         self.assertEqual(self.events, expected_events)
@@ -75,3 +78,7 @@ class ActionTestCase(TestCase):
     # If a message does not contain a text message, it appears as None in the list
     def assert_texts(self, expected_texts: List[Dict[str, Any]]) -> None:
         self.assertEqual(self.texts, expected_texts)
+
+    # If a message does not contain an attachment, it appears as None in the list
+    def assert_attachments(self, expected_attachments: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.attachments, expected_attachments)

--- a/action-server/tests/actions/form_helper.py
+++ b/action-server/tests/actions/form_helper.py
@@ -10,12 +10,14 @@ PHONE_TRY_COUNTER_SLOT = "daily_ci_enroll__phone_number_error_counter"
 CODE_TRY_COUNTER_SLOT = "daily_ci_enroll__validation_code_error_counter"
 WANTS_CANCEL_SLOT = "daily_ci_enroll__wants_cancel"
 NO_CODE_SOLUTION_SLOT = "daily_ci_enroll__no_code_solution"
+INVALID_POSTAL_CODE_COUNTER_SLOT = "test_navigation__invalid_postal_code_counter"
 
 INITIAL_SLOT_VALUES = {
     PHONE_TRY_COUNTER_SLOT: 0,
     CODE_TRY_COUNTER_SLOT: 0,
     WANTS_CANCEL_SLOT: False,
     NO_CODE_SOLUTION_SLOT: "N/A",
+    INVALID_POSTAL_CODE_COUNTER_SLOT: 0,
 }
 
 
@@ -69,6 +71,9 @@ class FormTestCase(TestCase):
         self.templates = [message["template"] for message in self.dispatcher.messages]
         self.json_messages = [message["custom"] for message in self.dispatcher.messages]
         self.texts = [message["text"] for message in self.dispatcher.messages]
+        self.attachments = [
+            message["attachment"] for message in self.dispatcher.messages
+        ]
 
     def assert_events(self, expected_events: List[Dict]) -> None:
         self.assertEqual(self.events, expected_events)
@@ -84,3 +89,7 @@ class FormTestCase(TestCase):
     # If a message does not contain a text message, it appears as None in the list
     def assert_texts(self, expected_texts: List[Dict[str, Any]]) -> None:
         self.assertEqual(self.texts, expected_texts)
+
+    # If a message does not contain an attachment, it appears as None in the list
+    def assert_attachments(self, expected_attachments: List[Dict[str, Any]]) -> None:
+        self.assertEqual(self.attachments, expected_attachments)

--- a/action-server/tests/actions/test_daily_ci_enroll_form.py
+++ b/action-server/tests/actions/test_daily_ci_enroll_form.py
@@ -1,4 +1,3 @@
-# type: ignore
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -31,12 +30,6 @@ from .form_helper import FormTestCase
 FIRST_NAME = "John"
 PHONE_NUMBER = "15141234567"
 VALIDATION_CODE = "4567"
-
-INITIAL_SLOT_VALUES = {
-    PHONE_TRY_COUNTER_SLOT: 0,
-    CODE_TRY_COUNTER_SLOT: 0,
-    WANTS_CANCEL_SLOT: False,
-}
 
 
 def AsyncMock(*args, **kwargs):

--- a/action-server/tests/actions/test_test_navigation_form.py
+++ b/action-server/tests/actions/test_test_navigation_form.py
@@ -1,0 +1,564 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rasa_sdk.events import Form, SlotSet
+from rasa_sdk.forms import REQUESTED_SLOT
+
+from covidflow.actions.constants import TEST_NAVIGATION_SUCCESS_SLOT
+from covidflow.actions.test_navigation_form import (
+    END_FORM_SLOT,
+    FORM_NAME,
+    INVALID_POSTAL_CODE_COUNTER_SLOT,
+    LOCATIONS_SLOT,
+    POSTAL_CODE_SLOT,
+    TRY_DIFFERENT_ADDRESS_SLOT,
+    TestNavigationForm,
+    _locations_carousel,
+)
+from covidflow.utils.testing_locations import TestingLocation
+
+from .form_helper import FormTestCase
+
+DOMAIN = {
+    "responses": {
+        "utter_test_navigation__display_titles": [
+            {
+                "custom": {
+                    "call_button": "Click to call: ",
+                    "directions_button": "Click to go",
+                }
+            }
+        ]
+    }
+}
+
+POSTAL_CODE = "H0H 0H0"
+INVALID_POSTAL_CODE = "0H0 H0H"
+
+GEOCODE = (0, 0)
+TESTING_LOCATION_RAW = {
+    "id": "result",
+    "name": "name",
+    "_geoPoint": {"lon": -73.6662946, "lat": 45.4758369},
+}
+TESTING_LOCATION = TestingLocation(TESTING_LOCATION_RAW)
+TESTING_LOCATION_CARD_CONTENT = {
+    "buttons": [
+        {
+            "title": "Click to go",
+            "type": "web_url",
+            "url": "http://maps.apple.com/?q=45.4758369,-73.6662946",
+        }
+    ],
+    "image_url": "some_url",
+    "subtitle": "",
+    "title": "name",
+}
+
+SINGLE_CAROUSEL_CONTENT = {
+    "type": "template",
+    "payload": {
+        "template_type": "generic",
+        "elements": [TESTING_LOCATION_CARD_CONTENT],
+    },
+}
+
+DOUBLE_CAROUSEL_CONTENT = {
+    "type": "template",
+    "payload": {
+        "template_type": "generic",
+        "elements": [TESTING_LOCATION_CARD_CONTENT, TESTING_LOCATION_CARD_CONTENT],
+    },
+}
+
+
+def AsyncMock(*args, **kwargs):
+    mock = MagicMock(*args, **kwargs)
+
+    async def mock_coroutine(*args, **kwargs):
+        return mock(*args, **kwargs)
+
+    mock_coroutine.mock = mock
+    return mock_coroutine
+
+
+class TestTestNavigationForm(FormTestCase):
+    def setUp(self):
+        super().setUp()
+        self.geocoding_patcher = patch(
+            "covidflow.actions.test_navigation_form.Geocoding"
+        )
+        # Safeguard only, test using the mock should re-patch with AsyncMock
+        self.testing_locations_patcher = patch(
+            "covidflow.actions.test_navigation_form.get_testing_locations",
+        )
+        self.mock_geocoding = self.geocoding_patcher.start()
+        self.testing_locations_patcher.start()
+        self.form = TestNavigationForm()
+
+    def tearDown(self):
+        super().tearDown()
+        self.geocoding_patcher.stop()
+        self.testing_locations_patcher.stop()
+
+    def _set_geocode(self, geocode=GEOCODE, exception=False):
+        if exception:
+            self.mock_geocoding.return_value.get_from_posta_code.side_effect = Exception
+        else:
+            self.mock_geocoding.return_value.get_from_postal_code.return_value = geocode
+
+    @pytest.mark.asyncio
+    async def test_validate_postal_code(self):
+        self._set_geocode()
+        slot_mapping = self.form.slot_mappings()[POSTAL_CODE_SLOT]
+        self.assertEqual(slot_mapping, self.form.from_text())
+
+        await self._validate_postal_code("H0H 0H0", "H0H 0H0")
+        await self._validate_postal_code("H0H0H0", "H0H0H0")
+        await self._validate_postal_code("h0h 0h0", "h0h 0h0")
+        await self._validate_postal_code("h0h0h0", "h0h0h0")
+        await self._validate_postal_code("it's H0H 0H0!", "H0H 0H0")
+        await self._validate_postal_code("it's h0h0h0", "h0h0h0")
+        await self._validate_postal_code("0H0 H0H", None)
+        await self._validate_postal_code("h0h 000", None)
+
+    async def _validate_postal_code(self, text: str, expected_postal_code: str):
+        tracker = self.create_tracker()
+        slot_values = await self.form.validate_test_navigation__postal_code(
+            text, self.dispatcher, tracker, None
+        )
+
+        self.assertEqual(expected_postal_code, slot_values.get(POSTAL_CODE_SLOT, None))
+
+    def test_initialize(self):
+        tracker = self.create_tracker(active_form=False)
+
+        self.run_form(tracker)
+
+        self.assert_events([Form(FORM_NAME), SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT)])
+
+        self.assert_templates(["utter_ask_test_navigation__postal_code"])
+
+    def test_postal_code_invalid_format(self):
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=INVALID_POSTAL_CODE
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(INVALID_POSTAL_CODE_COUNTER_SLOT, 1),
+                SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__invalid_postal_code",
+                "utter_ask_test_navigation__postal_code",
+            ]
+        )
+
+    def test_postal_code_invalid_format_twice(self):
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: POSTAL_CODE_SLOT,
+                INVALID_POSTAL_CODE_COUNTER_SLOT: 1,
+            },
+            text=INVALID_POSTAL_CODE,
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(INVALID_POSTAL_CODE_COUNTER_SLOT, 2),
+                SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__invalid_postal_code",
+                "utter_ask_test_navigation__postal_code",
+            ]
+        )
+
+    def test_postal_code_invalid_format_thrice(self):
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: POSTAL_CODE_SLOT,
+                INVALID_POSTAL_CODE_COUNTER_SLOT: 2,
+            },
+            text=INVALID_POSTAL_CODE,
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(END_FORM_SLOT, True),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(["utter_test_navigation__invalid_postal_code_max"])
+
+    def test_postal_code_geocoding_error(self):
+        self._set_geocode(exception=True)
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
+                SlotSet(END_FORM_SLOT, True),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__could_not_fetch_1",
+                "utter_test_navigation__could_not_fetch_2",
+            ]
+        )
+
+    def test_postal_code_nonexistent(self):
+        self._set_geocode(None)
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(INVALID_POSTAL_CODE_COUNTER_SLOT, 1),
+                SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__invalid_postal_code",
+                "utter_ask_test_navigation__postal_code",
+            ]
+        )
+
+    def test_postal_code_nonexistent_twice(self):
+        self._set_geocode(None)
+
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: POSTAL_CODE_SLOT,
+                INVALID_POSTAL_CODE_COUNTER_SLOT: 1,
+            },
+            text=POSTAL_CODE,
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(INVALID_POSTAL_CODE_COUNTER_SLOT, 2),
+                SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__invalid_postal_code",
+                "utter_ask_test_navigation__postal_code",
+            ]
+        )
+
+    def test_postal_code_nonexistent_thrice(self):
+        self._set_geocode(None)
+
+        tracker = self.create_tracker(
+            slots={
+                REQUESTED_SLOT: POSTAL_CODE_SLOT,
+                INVALID_POSTAL_CODE_COUNTER_SLOT: 2,
+            },
+            text=POSTAL_CODE,
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, None),
+                SlotSet(END_FORM_SLOT, True),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(["utter_test_navigation__invalid_postal_code_max"])
+
+    @patch(
+        "covidflow.actions.test_navigation_form.get_testing_locations",
+        new=AsyncMock(side_effect=Exception),
+    )
+    def test_postal_code_locations_error(self):
+        self._set_geocode()
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
+                SlotSet(END_FORM_SLOT, True),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__could_not_fetch_1",
+                "utter_test_navigation__could_not_fetch_2",
+            ]
+        )
+
+    @patch(
+        "covidflow.actions.test_navigation_form.get_testing_locations",
+        new=AsyncMock(return_value=[]),
+    )
+    def test_postal_code_no_results(self):
+        self._set_geocode(GEOCODE)
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
+                SlotSet(LOCATIONS_SLOT, []),
+                SlotSet(REQUESTED_SLOT, TRY_DIFFERENT_ADDRESS_SLOT),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__no_locations",
+                "utter_ask_test_navigation__try_different_address",
+            ]
+        )
+
+    @patch(
+        "covidflow.actions.test_navigation_form.get_map_url", return_value="some_url"
+    )
+    @patch(
+        "covidflow.actions.test_navigation_form.get_testing_locations",
+        new=AsyncMock(return_value=[TESTING_LOCATION]),
+    )
+    def test_postal_code_one_result(self, mock_maps):
+        self._set_geocode(GEOCODE)
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker, DOMAIN)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
+                SlotSet(LOCATIONS_SLOT, [TESTING_LOCATION_RAW]),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(["utter_test_navigation__one_location", None])
+
+        self.assert_attachments([None, SINGLE_CAROUSEL_CONTENT])
+
+    @patch(
+        "covidflow.actions.test_navigation_form.get_map_url", return_value="some_url"
+    )
+    @patch(
+        "covidflow.actions.test_navigation_form.get_testing_locations",
+        new=AsyncMock(return_value=[TESTING_LOCATION, TESTING_LOCATION]),
+    )
+    def test_postal_code_many_results(self, mock_maps):
+        self._set_geocode(GEOCODE)
+
+        tracker = self.create_tracker(
+            slots={REQUESTED_SLOT: POSTAL_CODE_SLOT}, text=POSTAL_CODE
+        )
+
+        self.run_form(tracker, DOMAIN)
+
+        self.assert_events(
+            [
+                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
+                SlotSet(LOCATIONS_SLOT, [TESTING_LOCATION_RAW, TESTING_LOCATION_RAW]),
+                SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, True),
+                Form(None),
+                SlotSet(REQUESTED_SLOT, None),
+            ]
+        )
+
+        self.assert_templates(
+            [
+                "utter_test_navigation__many_locations_1",
+                "utter_test_navigation__many_locations_2",
+                "utter_test_navigation__many_locations_3",
+                None,
+            ]
+        )
+
+        self.assert_attachments([None, None, None, DOUBLE_CAROUSEL_CONTENT])
+
+
+class TestLocationsCarousel(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+        self.patcher = patch(
+            "covidflow.actions.test_navigation_form.get_map_url",
+            return_value="some_url",
+        )
+        self.patcher.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patcher.stop()
+
+    def _test_locations_carousel(self, raw_test_locations, cards_contents):
+        test_locations = [TestingLocation(location) for location in raw_test_locations]
+        self.assertEqual(
+            _locations_carousel("ph", DOMAIN, test_locations),
+            {
+                "type": "template",
+                "payload": {"template_type": "generic", "elements": cards_contents},
+            },
+        )
+
+    def test_carousel_one_location(self):
+
+        self._test_locations_carousel(
+            [TESTING_LOCATION_RAW], [TESTING_LOCATION_CARD_CONTENT]
+        )
+
+    def test_carousel_many_locations(self):
+        card_1_content = {
+            "buttons": [
+                {
+                    "title": "Click to go",
+                    "type": "web_url",
+                    "url": "http://maps.apple.com/?q=45.4758369,-73.6662946",
+                }
+            ],
+            "image_url": "some_url",
+            "subtitle": "",
+            "title": "name",
+        }
+        location_2_raw = {
+            "id": "result-2",
+            "name": "name-2",
+            "_geoPoint": {"lon": 2.0, "lat": 2.0},
+        }
+        card_2_content = {
+            "buttons": [
+                {
+                    "title": "Click to go",
+                    "type": "web_url",
+                    "url": "http://maps.apple.com/?q=2.0,2.0",
+                }
+            ],
+            "image_url": "some_url",
+            "subtitle": "",
+            "title": "name-2",
+        }
+
+        self._test_locations_carousel(
+            [TESTING_LOCATION_RAW, location_2_raw], [card_1_content, card_2_content]
+        )
+
+    def test_carousel_all_details(self):
+        raw_location = {
+            "id": "result",
+            "name": "Test site name",
+            "description": {
+                "ph": "Test location described",
+                "en": "serious description",
+            },
+            "_geoPoint": {"lon": 33.3333, "lat": 34.5678},
+            "phones": [{"number": "5141112222", "extension": None, "type": "MAIN"}],
+        }
+        card_content = {
+            "buttons": [
+                {
+                    "title": "Click to call: 514-111-2222",
+                    "type": "web_url",
+                    "url": "tel:514-111-2222",
+                },
+                {
+                    "title": "Click to go",
+                    "type": "web_url",
+                    "url": "http://maps.apple.com/?q=34.5678,33.3333",
+                },
+            ],
+            "image_url": "some_url",
+            "subtitle": "Test location described",
+            "title": "Test site name",
+        }
+
+        self._test_locations_carousel([raw_location], [card_content])
+
+    def test_carousel_phone_with_extension(self):
+        raw_location = {
+            "id": "result",
+            "name": "name",
+            "_geoPoint": {"lon": 0.0, "lat": 0.0},
+            "phones": [{"number": "5141112222", "extension": "3333", "type": "MAIN"}],
+        }
+        card_content = {
+            "buttons": [
+                {
+                    "title": "Click to call: 514-111-2222 ext. 3333",
+                    "type": "web_url",
+                    "url": "tel:514-111-2222",
+                },
+                {
+                    "title": "Click to go",
+                    "type": "web_url",
+                    "url": "http://maps.apple.com/?q=0.0,0.0",
+                },
+            ],
+            "image_url": "some_url",
+            "subtitle": "",
+            "title": "name",
+        }
+
+        self._test_locations_carousel([raw_location], [card_content])

--- a/action-server/tests/utils/test_phone_number_validation.py
+++ b/action-server/tests/utils/test_phone_number_validation.py
@@ -1,4 +1,3 @@
-# type: ignore
 from unittest import TestCase, skip
 from unittest.mock import patch
 

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -1111,7 +1111,7 @@
   - utter_test_navigation__come_back
   - action_goodbye
 
-## Test navigation - ask question - failure
+## Test navigation - early ask question - failure
 * navigate_test_locations
   - action_test_navigation_explanations
   - utter_ask_test_navigation__continue_no_assessment
@@ -1126,7 +1126,7 @@
   - utter_try_again_later
   - action_qa_goodbye
 
-## Test navigation - ask question - need assessment
+## Test navigation - early ask question - need assessment
 * navigate_test_locations
   - action_test_navigation_explanations
   - utter_ask_test_navigation__continue_no_assessment
@@ -1141,7 +1141,7 @@
   - utter_please_visit_again
   - action_qa_goodbye
 
-## Test navigation - ask question - success
+## Test navigation - early ask question - success
 * navigate_test_locations
   - action_test_navigation_explanations
   - utter_ask_test_navigation__continue_no_assessment
@@ -1154,7 +1154,7 @@
 * done
   - action_qa_goodbye
 
-## Test navigation - ask question - two questions
+## Test navigation - early ask question - two questions
 * navigate_test_locations
   - action_test_navigation_explanations
   - utter_ask_test_navigation__continue_no_assessment
@@ -1175,10 +1175,52 @@
   - utter_try_again_later
   - action_qa_goodbye
 
-## Test navigation - navigate tests
+## Test navigation - navigate tests - failure
 * navigate_test_locations
   - action_test_navigation_explanations
   - utter_ask_test_navigation__continue_no_assessment
 * continue
   - utter_test_navigation__acknowledge_continue
-  - utter_test_navigation__placeholder
+  - test_navigation_form
+  - form{"name": "test_navigation_form"}
+  - form{"name": null}
+  - slot{"test_navigation_success": false}
+  - utter_test_navigation__anything_else_no_assessment
+* done
+  - action_goodbye
+
+## Test navigation - navigate tests - success
+* navigate_test_locations
+  - action_test_navigation_explanations
+  - utter_ask_test_navigation__continue_no_assessment
+* continue
+  - utter_test_navigation__acknowledge_continue
+  - test_navigation_form
+  - form{"name": "test_navigation_form"}
+  - form{"name": null}
+  - slot{"test_navigation_success": true}
+  - utter_test_navigation__what_next_no_assessment
+* done
+  - action_goodbye
+
+## Test navigation - navigate tests - success - question
+* navigate_test_locations
+  - action_test_navigation_explanations
+  - utter_ask_test_navigation__continue_no_assessment
+* continue
+  - utter_test_navigation__acknowledge_continue
+  - test_navigation_form
+  - form{"name": "test_navigation_form"}
+  - form{"name": null}
+  - slot{"test_navigation_success": true}
+  - utter_test_navigation__what_next_no_assessment
+* ask_question
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "failure"}
+  - utter_question_answering_error
+  - utter_ask_assess_after_error
+* deny
+  - utter_try_again_later
+  - action_qa_goodbye

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -34,7 +34,8 @@ intents:
       triggers: action_send_validation_code
   - send_daily_checkin_reminder:
       triggers: action_send_daily_checkin_reminder
-  - navigate_test_locations
+  - navigate_test_locations:
+      use_entities: []
   - later
 
 entities:
@@ -77,6 +78,7 @@ forms:
   - daily_ci_keep_or_cancel_form
   - question_answering_form
   - home_assistance_form
+  - test_navigation_form
 
 slots:
   metadata:
@@ -150,6 +152,8 @@ slots:
     values:
       - success
       - failure
+      - need_assessment
+      - out_of_distribution
 
   has_contact_risk:
     type: bool
@@ -185,6 +189,9 @@ slots:
     type: unfeaturized
 
   invalid_reminder_id:
+    type: bool
+
+  test_navigation_success:
     type: bool
 
   checkin_return__moderate_symptoms_worsened:
@@ -231,6 +238,22 @@ slots:
     type: unfeaturized
 
   daily_ci__feel_better__is_symptom_free:
+    type: unfeaturized
+
+  test_navigation__postal_code:
+    type: unfeaturized
+
+  test_navigation__invalid_postal_code_counter:
+    type: unfeaturized
+    initial_value: 0
+
+  test_navigation__try_different_address:
+    type: unfeaturized
+
+  test_navigation__locations:
+    type: unfeaturized
+
+  test_navigation__end_form:
     type: unfeaturized
 
 session_config:

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -444,14 +444,12 @@ responses:
     - text: "I can help answer your questions about Covid-19, on many different topics"
 
   utter_qa_disclaimer:
-    - text:
-        "Please note that at the moment, I can provide answers to a limited
+    - text: "Please note that at the moment, I can provide answers to a limited
         number of questions, but I'm constantly improving and learning from the
         questions you ask me"
 
   utter_qa_sample:
-    - text:
-        "Here are some examples of questions you can ask:\n{sample_questions}"
+    - text: "Here are some examples of questions you can ask:\n{sample_questions}"
 
   utter_qa_sample_animal:
     - text: "Can my cat get the virus?"
@@ -462,8 +460,7 @@ responses:
   utter_qa_sample_contagion:
     - text: "If we have covid-19, how long are we contagious?"
     - text: "How long are we contagious when we have COVID-19?"
-    - text:
-        "After symptoms disappear, how long does a person remain contagious?"
+    - text: "After symptoms disappear, how long does a person remain contagious?"
     - text: "How long is a person contagious?"
     - text: "Am I contagious long after I get the virus?"
 
@@ -471,8 +468,7 @@ responses:
     - text: "Is it true that warmth kills Coronavirus?"
     - text: "How long does the virus live on surfaces?"
     - text: "How long COVID19 can stay alive on different surfaces?"
-    - text:
-        "Is it true that COVID-19 can survive up to a few days on hard surfaces?"
+    - text: "Is it true that COVID-19 can survive up to a few days on hard surfaces?"
     - text: "How long does the virus survive on a surface like a doorknob?"
     - text: "How long is COVID-19 staying on surfaces?"
 
@@ -496,8 +492,7 @@ responses:
     - text: "How do I distinguish between the flu and coronavirus?"
     - text: "What is the difference between covid-19 and influenza?"
     - text: "How do you differentiate between covid and flu?"
-    - text:
-        "What is the difference between the symptoms of influenza and COVID-19?"
+    - text: "What is the difference between the symptoms of influenza and COVID-19?"
     - text: "How to tell the difference between covid and a simple flu?"
     - text: "What should I do if I am short of breath?"
     - text: "How to know if I have COVID-19 or not?"
@@ -546,8 +541,7 @@ responses:
     - text: "Am I allowed to go outside?"
 
   utter_qa_sample_stats:
-    - text:
-        "From the infected worldwide population what will be the ratio of
+    - text: "From the infected worldwide population what will be the ratio of
         asymptomatic people?"
     - text: "Where can I find most up to date numbers on cases and deaths?"
     - text: "How many cases in Montreal?"
@@ -1075,5 +1069,84 @@ responses:
   utter_test_navigation__acknowledge_continue:
     - text: OK, let’s continue!
 
-  utter_test_navigation__placeholder:
-    - text: What follows will row to here soon...
+  utter_ask_test_navigation__postal_code:
+    - text: To find the nearest testing sites, please type in your postal code
+
+  utter_test_navigation__invalid_postal_code:
+    - text: I’m sorry, this is not a valid postal code. Please try again
+
+  utter_test_navigation__invalid_postal_code_max:
+    - text: I’m sorry, this is still not a valid postal code. I will not be able to search for testing sites
+
+  utter_test_navigation__could_not_fetch_1:
+    - text: I’m sorry, I’m not able to find any testing sites at the moment
+
+  utter_test_navigation__could_not_fetch_2:
+    - text: Please try again later
+
+  utter_test_navigation__no_locations:
+    - text: I’m sorry, I can’t find any sites near that address
+
+  utter_test_navigation__one_location:
+    - text: I found 1 testing site in your area
+
+  utter_test_navigation__many_locations_1:
+    - text: I found {nb_testing_sites} testing sites in your area
+
+  utter_test_navigation__many_locations_2:
+    - text: For each testing site, you can get detailed contact information, directions and opening hours
+
+  utter_test_navigation__many_location_3:
+    - text: You will need to contact the testing site directly for more information or to make an appointment to get tested
+
+  utter_test_navigation__display_titles:
+    - custom:
+        call_button: "Call "
+        directions_button: "Directions"
+
+  utter_ask_test_navigation__try_different_address:
+    - text: Would you like to try a different address?
+      buttons:
+        - title: Yes
+          payload: "/affirm"
+        - title: No
+          payload: "/deny"
+
+  utter_test_navigation__acknowledge:
+    - text: OK
+
+  utter_test_navigation__what_next_no_assessment:
+    - text: What else may I help you with?
+      buttons:
+        - title: Assess my symptoms
+          payload: /get_assessment
+        - title: I have other questions
+          payload: /ask_question
+        - title: I’m done
+          payload: /done
+
+  utter_test_navigation__what_next_assessment_done:
+    - text: What else may I help you with?
+      buttons:
+        - title: I have other questions
+          payload: /ask_question
+        - title: I’m done
+          payload: /done
+
+  utter_test_navigation__anything_else_no_assessment:
+    - text: May I help you with anything else?
+      buttons:
+        - title: Yes assess my symptoms
+          payload: /get_assessment
+        - title: Yes I have other questions
+          payload: /ask_question
+        - title: No I’m done
+          payload: /done
+
+  utter_test_navigation__anything_else_assessment_done:
+    - text: May I help you with anything else?
+      buttons:
+        - title: Yes I have other questions
+          payload: /ask_question
+        - title: No I’m done
+          payload: /done

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -444,14 +444,12 @@ responses:
     - text: "Je peux répondre à vos questions sur une variété de sujets entourant la Covid-19"
 
   utter_qa_disclaimer:
-    - text:
-        "Veuillez noter que pour le moment, je suis en mesure de répondre à un
+    - text: "Veuillez noter que pour le moment, je suis en mesure de répondre à un
         nombre limité de questions, mais je m'améliore constamment et j'apprends
         à l'aide des questions que vous me posez"
 
   utter_qa_sample:
-    - text:
-        "Voici des exemples de questions que vous pouvez
+    - text: "Voici des exemples de questions que vous pouvez
         poser:\n{sample_questions}"
 
   utter_qa_sample_animal:
@@ -463,8 +461,7 @@ responses:
   utter_qa_sample_contagion:
     - text: "Si nous avons Covid-19, combien de temp sommes-nous contagieux?"
     - text: "Combien de temps sommes-nous contagieux quand nous avons Covid-19?"
-    - text:
-        "Après la disparition des symptômes, combien de temps une personne reste
+    - text: "Après la disparition des symptômes, combien de temps une personne reste
         contagieuse?"
     - text: "Combien de temps une personne est-elle contagieuse?"
     - text: "Suis-je contagieux longtemps après que j'ai contracté le virus?"
@@ -472,17 +469,13 @@ responses:
   utter_qa_sample_resistance:
     - text: "Est-il vrai que la chaleur tue le coronavirus?"
     - text: "Combien de temp le virus vit-il sur des surfaces?"
-    - text:
-        "Pour combien de temps COVID19 peut rester en vie sur des surfaces
+    - text: "Pour combien de temps COVID19 peut rester en vie sur des surfaces
         différentes?"
-    - text:
-        "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
+    - text: "Est-il vrai que Covid-19 peut survivre jusqu'à quelques jours sur les
         surfaces dures?"
-    - text:
-        "Combien de temps le virus survit-il sur une surface comme une poignée
+    - text: "Combien de temps le virus survit-il sur une surface comme une poignée
         de porte?"
-    - text:
-        "Combien de temps est-ce que la Covid 19 peut rester sur des surfaces?"
+    - text: "Combien de temps est-ce que la Covid 19 peut rester sur des surfaces?"
 
   utter_qa_sample_cure:
     - text: "Combien de temps faudra-t-il pour développer un vaccin?"
@@ -499,8 +492,7 @@ responses:
     - text: "Comment puis-je distinguer entre la grippe et le coronavirus?"
     - text: "Quelle est la différence entre Covid-19 et la grippe?"
     - text: "Comment différenciez-vous entre Covid et la grippe?"
-    - text:
-        "Quelle est la différence entre les symptômes de la grippe et Covid-19?"
+    - text: "Quelle est la différence entre les symptômes de la grippe et Covid-19?"
     - text: "Comment faire la différence entre Covid et une simple grippe?"
     - text: "J'ai un mal de tête et une gorge qui démange. Suis-je à risque?"
     - text: "Comment puis-je savoir si j'ai le coronavirus?"
@@ -535,8 +527,7 @@ responses:
     - text: "Comment prévenir la propagation de Covid-19?"
     - text: "Comment puis-je me protéger contre la Covid-19?"
     - text: "Précautions à prendre?"
-    - text:
-        "Est-ce que me laver les mains est vraiment la meilleure façon de
+    - text: "Est-ce que me laver les mains est vraiment la meilleure façon de
         prévenir la transmission?"
     - text: "Dois-je pratiquer la distanciation sociale?"
     - text: "Qu'est-ce que la distanciation sociale?"
@@ -556,15 +547,13 @@ responses:
     - text: "Suis-je autorisé à aller à l'extérieur?"
 
   utter_qa_sample_stats:
-    - text:
-        "Où puis-je trouver les statistiques à jour sur les cas et les décès?"
+    - text: "Où puis-je trouver les statistiques à jour sur les cas et les décès?"
     - text: "Combien de cas à Montréal?"
     - text: "Combien de personnes sont mortes à ce jour?"
     - text: "Combien de cas au Québec?"
     - text: "Combien de personnes sont infectées au Québec?"
     - text: "Combien de cas sont aux États-Unis?"
-    - text:
-        "De la population infectée dans le monde entier quel sera le rapport des
+    - text: "De la population infectée dans le monde entier quel sera le rapport des
         personnes asymptomatiques?"
 
   utter_ask_active_question:
@@ -1086,5 +1075,84 @@ responses:
   utter_test_navigation__acknowledge_continue:
     - text: D’accord, continuons!
 
-  utter_test_navigation__placeholder:
-    - text: Ce qui suit ramera bientôt jusqu'ici...
+  utter_ask_test_navigation__postal_code:
+    - text: Pour trouver la clinique la plus près, veuillez entrer votre code postal
+
+  utter_test_navigation__invalid_postal_code:
+    - text: Je suis désolée, ce code postal n’est pas valide. Veuillez essayer de nouveau
+
+  utter_test_navigation__invalid_postal_code_max:
+    - text: Je suis désolée, ce n’est toujours pas un code postal valide. Je ne serai pas en mesure de chercher une clinique
+
+  utter_test_navigation__could_not_fetch_1:
+    - text: Je suis désolée, je ne suis pas en mesure de trouver de clinique en ce moment
+
+  utter_test_navigation__could_not_fetch_2:
+    - text: Veuillez essayer plus tard
+
+  utter_test_navigation__no_locations:
+    - text: Je suis désolée, je ne trouve aucune clinique à proximité de cet emplacement
+
+  utter_test_navigation__one_location:
+    - text: J’ai trouvé une clinique de dépistage dans votre région
+
+  utter_test_navigation__many_locations_1:
+    - text: J’ai trouvé {nb_testing_sites} cliniques de dépistage dans votre région
+
+  utter_test_navigation__many_locations_2:
+    - text: Pour chaque clinique, vous pouvez obtenir les coordonnées, l’itinéraire et les heures d’ouverture
+
+  utter_test_navigation__many_location_3:
+    - text: Vous devrez communiquer directement avec la clinique pour plus d’information ou pour prendre rendez-vous pour un test
+
+  utter_test_navigation__display_titles:
+    - custom:
+        call_button: "Appeler le "
+        directions_button: "Itinéraire"
+
+  utter_ask_test_navigation__try_different_address:
+    - text: Voudriez-vous essayer une autre adresse?
+      buttons:
+        - title: Oui
+          payload: "/affirm"
+        - title: Non
+          payload: "/deny"
+
+  utter_test_navigation__acknowledge:
+    - text: D'accord
+
+  utter_test_navigation__what_next_no_assessment:
+    - text: Que puis-je faire d’autre pour vous aider?
+      buttons:
+        - title: Évaluer mes symptômes
+          payload: /get_assessment
+        - title: J’ai d’autres questions
+          payload: /ask_question
+        - title: J’ai terminé
+          payload: /done
+
+  utter_test_navigation__what_next_assessment_done:
+    - text: Que puis-je faire d’autre pour vous aider?
+      buttons:
+        - title: J’ai d’autres questions
+          payload: /ask_question
+        - title: J’ai terminé
+          payload: /done
+
+  utter_test_navigation__anything_else_no_assessment:
+    - text: Puis-je faire autre chose pour vous aider?
+      buttons:
+        - title: Oui évaluer mes symptômes
+          payload: /get_assessment
+        - title: Oui j’ai des questions
+          payload: /ask_question
+        - title: Non j’ai terminé
+          payload: /done
+
+  utter_test_navigation__anything_else_assessment_done:
+    - text: Puis-je faire autre chose pour vous aider?
+      buttons:
+        - title: Oui j’ai des questions
+          payload: /ask_question
+        - title: Non j’ai terminé
+          payload: /done

--- a/core/scripts/validate_domain.py
+++ b/core/scripts/validate_domain.py
@@ -28,6 +28,7 @@ RESPONSE_VARIANTS_EXCLUSIONS = {
     "utter_qa_sample_tests",
     "utter_qa_sample_walk",
     "utter_qa_sample_stats",
+    "utter_test_navigation__display_titles",
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,9 @@ services:
       - SQL_TRACKER_STORE_DB=chloe
       - REMINDER_JOB_CORE_ENDPOINT_EN=http://core-en:8080
       - REMINDER_JOB_CORE_ENDPOINT_FR=http://core-fr:8080
+      - GOOGLE_GEOCODING_API_KEY
+      - GOOGLE_MAPS_API_KEY
+      - GOOGLE_MAPS_URL_SIGN_SECRET
     volumes:
       - ./action-server/covidflow:/app/covidflow
 


### PR DESCRIPTION
## Description

Flow to get test locations and what comes after, carousel included. An error should happen if there is no geocode for a location, but the lack of a phone number just removes the button

![image](https://user-images.githubusercontent.com/63261085/83065531-a75db780-a031-11ea-91b2-dc1cffc25d65.png)

Left out:
- link with extension on call button
- propose to try again with another postal code when the the first time was a success (retry inside the form when it doesn't work is implemented)
- geolocalisation
- more information button

## Related issues

closes #282

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
