### PR TITLE
feat(flow): generate testing location description (#311)

### DIFF
--- a/action-server/covidflow/utils/testing_locations.py
+++ b/action-server/covidflow/utils/testing_locations.py
@@ -82,7 +82,7 @@ class TestingLocation:
         return self.raw_data.get("name")
 
     @property
-    def require_referal(self) -> Optional[bool]:
+    def require_referral(self) -> Optional[bool]:
         return self.raw_data.get("requireReferral")
 
     @property

--- a/action-server/tests/utils/test_testing_locations.py
+++ b/action-server/tests/utils/test_testing_locations.py
@@ -127,7 +127,7 @@ class TestTestingLocationsClasses(TestCase):
         location = Location(SAMPLE)
 
         self.assertEqual(location.name, SAMPLE["name"])
-        self.assertEqual(location.require_referal, SAMPLE["requireReferral"])
+        self.assertEqual(location.require_referral, SAMPLE["requireReferral"])
         self.assertEqual(location.require_appointment, SAMPLE["requireAppointment"])
         self.assertEqual(location.coordinates[0], SAMPLE["_geoPoint"]["lat"])
         self.assertEqual(location.coordinates.latitude, SAMPLE["_geoPoint"]["lat"])
@@ -149,7 +149,7 @@ class TestTestingLocationsClasses(TestCase):
         location = Location({"_geoPoint": {"lon": 1, "lat": 0}})
 
         self.assertEqual(location.name, None)
-        self.assertEqual(location.require_referal, None)
+        self.assertEqual(location.require_referral, None)
         self.assertEqual(location.require_appointment, None)
         self.assertEqual(location.coordinates, (0.0, 1.0))
         self.assertEqual(location.clientele, None)

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -1096,13 +1096,46 @@ responses:
   utter_test_navigation__many_locations_2:
     - text: For each testing site, you can get detailed contact information, directions and opening hours
 
-  utter_test_navigation__many_location_3:
+  utter_test_navigation__many_locations_3:
     - text: You will need to contact the testing site directly for more information or to make an appointment to get tested
 
   utter_test_navigation__display_titles:
     - custom:
         call_button: "Call "
         directions_button: "Directions"
+
+  utter_test_navigation__descriptions:
+    - custom:
+        contact_before_visit: Please contact us before presenting yourself.
+        referral:
+          "true": Referral from a health professional needed.
+          "false": ""
+          "none": ""
+        appointment_clientele:
+          "false":
+            default: Walk-in clinic.
+            all: Walk-in clinic for all.
+            children: Children only walk-in clinic.
+            no_children: Adults only walk-in clinic.
+            no_children_under: Clinic for adults and children {age} years old or more.
+            no_children_under_months: Clinic for adults and children {age} months old or more.
+            healthcare_workers_and_first_responders: Healthcare workers and first responders only walk-in clinic.
+          "true":
+            default: By appointment only.
+            all: By appointment only.
+            children: Children only by appointment clinic.
+            no_children: Adults only by appointment clinic.
+            no_children_under: By appointment only. For adults and children {age} years old or more.
+            no_children_under_months: By appointment only. For adults and children {age} months old or more.
+            healthcare_workers_and_first_responders: Healthcare workers and first responders only walk-in clinic.
+          "none":
+            default: ""
+            all: Clinic for all.
+            children: Children only clinic.
+            no_children: Adults only clinic.
+            no_children_under: Clinic for adults and children {age} years old or more.
+            no_children_under_months: Clinic for adults and children {age} months old or more.
+            healthcare_workers_and_first_responders: Healthcare workers and first responders only clinic.
 
   utter_ask_test_navigation__try_different_address:
     - text: Would you like to try a different address?

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -1102,13 +1102,46 @@ responses:
   utter_test_navigation__many_locations_2:
     - text: Pour chaque clinique, vous pouvez obtenir les coordonnées, l’itinéraire et les heures d’ouverture
 
-  utter_test_navigation__many_location_3:
+  utter_test_navigation__many_locations_3:
     - text: Vous devrez communiquer directement avec la clinique pour plus d’information ou pour prendre rendez-vous pour un test
 
   utter_test_navigation__display_titles:
     - custom:
         call_button: "Appeler le "
         directions_button: "Itinéraire"
+
+  utter_test_navigation__descriptions:
+    - custom:
+        contact_before_visit: Veuillez nous contacter avant de vous présenter.
+        referral:
+          "true": Référence d'un professionnel de la santé requise.
+          "false": ""
+          "none": ""
+        appointment_clientele:
+          "false":
+            default: Clinique sans rendez-vous pour tous.
+            all: Clinique sans rendez-vous pour tous.
+            children: Clinique sans rendez-vous pour enfants seulement.
+            no_children: Clinique sans rendez-vous pour adultes seulement.
+            no_children_under: Clinique sans rendez-vous. Nous ne traitons pas les enfants de moins de {age} ans.
+            no_children_under_months: Clinique sans rendez-vous. Nous ne traitons pas les bébés de moins de {age} mois.
+            healthcare_workers_and_first_responders: Clinique sans rendez-vous pour travailleurs de la santé et premiers répondants seulement.
+          "true":
+            default: Uniquement sur rendez-vous.
+            all: Uniquement sur rendez-vous.
+            children: Clinique pour enfants sur rendez-vous seulement.
+            no_children: Clinique pour adultes sur rendez-vous seulement.
+            no_children_under: Uniquement sur rendez-vous. Nous ne traitons pas les enfants de moins de {age} ans.
+            no_children_under_months: Uniquement sur rendez-vous. Nous ne traitons pas les bébés de moins de {age} mois.
+            healthcare_workers_and_first_responders: Clinique pour travailleurs de la santé et premiers répondants sur rendez-vous seulement.
+          "none":
+            default: ""
+            all: Clinique pour tous.
+            children: Clinique pour enfants seulement.
+            no_children: Clinique pour adultes seulement.
+            no_children_under: Nous ne traitons pas les enfants de moins de {age} ans.
+            no_children_under_months: Nous ne traitons pas les bébés de moins de {age} mois.
+            healthcare_workers_and_first_responders: Clinique pour travailleurs de la santé et premiers répondants seulement.
 
   utter_ask_test_navigation__try_different_address:
     - text: Voudriez-vous essayer une autre adresse?

--- a/core/scripts/validate_domain.py
+++ b/core/scripts/validate_domain.py
@@ -29,6 +29,7 @@ RESPONSE_VARIANTS_EXCLUSIONS = {
     "utter_qa_sample_walk",
     "utter_qa_sample_stats",
     "utter_test_navigation__display_titles",
+    "utter_test_navigation__descriptions",
 }
 
 


### PR DESCRIPTION
## Description

Generates a description to include in the carousel card based on referral required, appointment required, and clientele. It doesn't follow exactly the design, but close enough. More clienteles were added so the age-related clientele messages are automated to support any age that could be sent.
Added a message for healthcare workers too.

![image](https://user-images.githubusercontent.com/63261085/83417767-8bbb2e00-a3f0-11ea-8232-f034004eb2d3.png)

![image](https://user-images.githubusercontent.com/63261085/83419376-f9685980-a3f2-11ea-9646-572e350bae40.png)


## Related issues

closes #311 

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
