### PR TITLE
feat: use address and display distance (#325)

### DIFF
--- a/action-server/covidflow/utils/geocoding.py
+++ b/action-server/covidflow/utils/geocoding.py
@@ -1,8 +1,9 @@
 import os
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Dict, Optional
 
 import googlemaps
 import structlog
+from geopy.point import Point
 
 logger = structlog.get_logger()
 
@@ -16,27 +17,22 @@ LATITUDE = "lat"
 LONGITUDE = "lng"
 
 
-class Coordinates(NamedTuple):
-    latitude: float
-    longitude: float
-
-
 class Geocoding:
     def __init__(self):
         key = os.environ[GOOGLE_API_KEY_ENV]
         self.client = googlemaps.Client(key=key)
 
-    def get_from_address(self, address: str) -> Optional[Coordinates]:
+    def get_from_address(self, address: str) -> Optional[Point]:
         request = {"address": address}
         return self._get_geocode(request)
 
-    def get_from_postal_code(self, postal_code: str) -> Optional[Coordinates]:
+    def get_from_postal_code(self, postal_code: str) -> Optional[Point]:
         request = {
             "components": {"postal_code": postal_code, "country": DEFAULT_COUNTRY}
         }
         return self._get_geocode(request)
 
-    def _get_geocode(self, request: Dict[str, Any]) -> Optional[Coordinates]:
+    def _get_geocode(self, request: Dict[str, Any]) -> Optional[Point]:
         geocode_result = self.client.geocode(**request)
 
         if (len(geocode_result)) == 0:
@@ -47,4 +43,4 @@ class Geocoding:
         if LATITUDE not in location or LONGITUDE not in location:
             return None
 
-        return Coordinates(location[LATITUDE], location[LONGITUDE])
+        return Point([location[LATITUDE], location[LONGITUDE]])

--- a/action-server/covidflow/utils/maps.py
+++ b/action-server/covidflow/utils/maps.py
@@ -4,7 +4,7 @@ import hmac
 import os
 from urllib.parse import urlencode
 
-from .geocoding import Coordinates
+from geopy.point import Point
 
 GOOGLE_API_KEY_ENV = "GOOGLE_MAPS_API_KEY"
 GOOGLE_SIGN_SECRET_ENV = "GOOGLE_MAPS_URL_SIGN_SECRET"
@@ -13,7 +13,7 @@ MAPS_ENDPOINT = "https://maps.googleapis.com"
 MAPS_API_PATH = "/maps/api/staticmap"
 
 
-def get_map_url(coordinates: Coordinates, size: str = "220x150", zoom: int = 15):
+def get_static_map_url(coordinates: Point, size: str = "220x150", zoom: int = 15):
     key = os.environ[GOOGLE_API_KEY_ENV]
     secret = os.environ[GOOGLE_SIGN_SECRET_ENV]
     parameters = {

--- a/action-server/mypy.ini
+++ b/action-server/mypy.ini
@@ -27,3 +27,6 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
+[mypy-geopy.*]
+ignore_missing_imports = True
+

--- a/action-server/poetry.lock
+++ b/action-server/poetry.lock
@@ -227,6 +227,32 @@ flake8 = "*"
 
 [[package]]
 category = "main"
+description = "The geodesic routines from GeographicLib"
+name = "geographiclib"
+optional = false
+python-versions = "*"
+version = "1.50"
+
+[[package]]
+category = "main"
+description = "Python Geocoding Toolbox"
+name = "geopy"
+optional = false
+python-versions = "*"
+version = "1.22.0"
+
+[package.dependencies]
+geographiclib = ">=1.49,<2"
+
+[package.extras]
+dev = ["mock", "six", "flake8 (>=3.6.0,<3.7.0)", "isort (>=4.3.4,<4.4.0)", "coverage", "pytest (>=3.10)", "readme-renderer", "sphinx", "sphinx-rtd-theme (>=0.4.0)", "contextlib2", "statistics"]
+dev-docs = ["readme-renderer", "sphinx", "sphinx-rtd-theme (>=0.4.0)"]
+dev-lint = ["mock", "six", "flake8 (>=3.6.0,<3.7.0)", "isort (>=4.3.4,<4.4.0)", "contextlib2"]
+dev-test = ["mock", "six", "coverage", "pytest (>=3.10)", "contextlib2", "statistics"]
+timezone = ["pytz"]
+
+[[package]]
+category = "main"
 description = "Python client library for Google Maps Platform"
 name = "googlemaps"
 optional = false
@@ -967,7 +993,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "2be320bbd7f448c8d614f2277f83515dd122b471cb2598c4095a5311981a597f"
+content-hash = "3fe250a82871438bea2d96d84fc47d06d8ef4d29fac9db2564b089acd84c3c26"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1087,6 +1113,14 @@ flake8 = [
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
+]
+geographiclib = [
+    {file = "geographiclib-1.50-py3-none-any.whl", hash = "sha256:51cfa698e7183792bce27d8fb63ac8e83689cd8170a730bf35e1a5c5bf8849b9"},
+    {file = "geographiclib-1.50.tar.gz", hash = "sha256:12bd46ee7ec25b291ea139b17aa991e7ef373e21abd053949b75c0e9ca55c632"},
+]
+geopy = [
+    {file = "geopy-1.22.0-py2.py3-none-any.whl", hash = "sha256:d0adba79a4c50a0e253d4a9d2d86aea4a3c1c2ec0889c5c61500ea914dafb9a5"},
+    {file = "geopy-1.22.0.tar.gz", hash = "sha256:f860fd1d68d5951551c676a871a7a2eee0ad3f1da2f2eb318b28fb45b19ad74b"},
 ]
 googlemaps = [
     {file = "googlemaps-4.4.0.tar.gz", hash = "sha256:0336594884640d5a299b84d2ec1700908d5d1d049ea08e7efddca5fc94226d23"},

--- a/action-server/pyproject.toml
+++ b/action-server/pyproject.toml
@@ -21,6 +21,7 @@ toolz = "^0.10.0"
 python-json-logger = "^0.1.11"
 sanic = "^19.12.2"
 googlemaps = "^4.4.0"
+geopy = "^1.22.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.4.1" # 5.4.2 breaks pytest-asyncio markers

--- a/action-server/tests/utils/test_geocoding.py
+++ b/action-server/tests/utils/test_geocoding.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from geopy.point import Point
+
 from covidflow.utils.geocoding import Geocoding
 
 ENV = {"GOOGLE_GEOCODING_API_KEY": "123abc"}
@@ -57,7 +59,7 @@ class GeocodingTest(TestCase):
             {"geometry": {"location": {"lat": 45, "lng": -75}}}
         ]
         location = Geocoding().get_from_address(ADDRESS)
-        self.assertEqual(location, (45, -75))
+        self.assertEqual(location, Point(45.0, -75.0))
         client.geocode.assert_called_once_with(address=ADDRESS)
 
     @patch.dict("os.environ", ENV)
@@ -69,7 +71,7 @@ class GeocodingTest(TestCase):
             {"geometry": {"location": {"lat": 45, "lng": -75}}}
         ]
         location = Geocoding().get_from_postal_code(postal_code=POSTAL_CODE)
-        self.assertEqual(location, (45, -75))
+        self.assertEqual(location, Point(45.0, -75.0))
         client.geocode.assert_called_once_with(
             components={"postal_code": "H0H0H0", "country": "CA"}
         )

--- a/action-server/tests/utils/test_maps.py
+++ b/action-server/tests/utils/test_maps.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from covidflow.utils.maps import _create_signature, get_map_url
+from covidflow.utils.maps import _create_signature, get_static_map_url
 
 ENV = {"GOOGLE_MAPS_API_KEY": "123abc", "GOOGLE_MAPS_URL_SIGN_SECRET": "123"}
 
@@ -11,13 +11,13 @@ COORDINATES = (-82.109835, 74.625658)
 class GeocodingTest(TestCase):
     def test_missing_environment_key(self):
         with self.assertRaises(expected_exception=KeyError):
-            get_map_url(COORDINATES)
+            get_static_map_url(COORDINATES)
 
     @patch.dict("os.environ", ENV)
     @patch("covidflow.utils.maps._create_signature", return_value="bobafett")
     def test_get_map(self, mock_create_signature):
         self.assertEqual(
-            get_map_url(COORDINATES),
+            get_static_map_url(COORDINATES),
             "https://maps.googleapis.com/maps/api/staticmap?markers=-82.109835%2C74.625658&zoom=15&key=123abc&size=220x150&signature=bobafett",
         )
 

--- a/action-server/tests/utils/test_testing_locations.py
+++ b/action-server/tests/utils/test_testing_locations.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 from aiohttp import ClientResponseError, web
 from aiohttp.test_utils import unused_port
+from geopy.point import Point
 
-from covidflow.utils.geocoding import Coordinates
 from covidflow.utils.testing_locations import (
     CLINIA_API_KEY,
     CLINIA_API_ROUTE,
@@ -67,7 +67,7 @@ class TestGetTestingLocations(TestCase):
     @patch.dict("os.environ", ENV)
     def _get_testing_locations(self):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(get_testing_locations(Coordinates(45, -75)))
+        return loop.run_until_complete(get_testing_locations(Point([45, -75])))
 
     def test_empty_result(self):
         self._setUp(create_api_success())
@@ -183,7 +183,7 @@ class TestTestingLocationsClasses(TestCase):
         self.assertEqual(location.name, None)
         self.assertEqual(location.require_referral, None)
         self.assertEqual(location.require_appointment, None)
-        self.assertEqual(location.coordinates, (0.0, 1.0))
+        self.assertEqual(location.coordinates, (0.0, 1.0, 0.0))
         self.assertEqual(location.clientele, None)
         self.assertEqual(location.websites, [])
         self.assertEqual(location.address, None)


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
There's no way to display the address in the static map and it was decided not to write it in the description, but if we have the address, then it is used for the directions link.

![image](https://user-images.githubusercontent.com/63261085/83907913-2f2f7a00-a734-11ea-825c-da5b781abc4e.png)




Straight distance is displayed for complexity reasons and lack of an appropriate API key. Since the means of transportation can change, an approximation is as good as a travel distance could be. Distance is displayed in the description since it would steal some space of the clinic name that is only on one line.

![image](https://user-images.githubusercontent.com/63261085/83907867-1cb54080-a734-11ea-8314-54af27b9c631.png)


## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #325

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
