### PR TITLE
fix: making tokenizer case insensitive

### DIFF
--- a/core/config/config.en.yml
+++ b/core/config/config.en.yml
@@ -4,6 +4,7 @@ language: en
 
 pipeline:
   - name: WhitespaceTokenizer
+    case_sensitive: false
   - name: RegexFeaturizer
   - name: LexicalSyntacticFeaturizer
   - name: CountVectorsFeaturizer

--- a/core/config/config.fr.yml
+++ b/core/config/config.fr.yml
@@ -2,6 +2,7 @@ language: "fr" # your two-letter language code
 
 pipeline:
   - name: WhitespaceTokenizer
+    case_sensitive: false
   - name: RegexFeaturizer
   - name: LexicalSyntacticFeaturizer
   - name: CountVectorsFeaturizer


### PR DESCRIPTION
## Description
In order to avoid this:

![image](https://user-images.githubusercontent.com/5585923/84059449-a3625b80-a988-11ea-8f17-80ee673aa5b6.png)

tokenizer set to `case_sensitive = false`

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
