### PR TITLE
feat(flow): make test navigation re-doable (#341)

### DIFF
--- a/action-server/covidflow/actions/test_navigation_form.py
+++ b/action-server/covidflow/actions/test_navigation_form.py
@@ -49,6 +49,14 @@ TEST_LOCATION_RESPONSE = TestingLocation(
     {"name": "location name", "_geoPoint": {"lon": 0.9, "lat": 0.0},}
 )
 
+CLEARED_SLOTS = [
+    SlotSet(POSTAL_CODE_SLOT),
+    SlotSet(INVALID_POSTAL_CODE_COUNTER_SLOT, 0),
+    SlotSet(TRY_DIFFERENT_ADDRESS_SLOT),
+    SlotSet(LOCATIONS_SLOT),
+    SlotSet(END_FORM_SLOT),
+]
+
 
 class TestNavigationForm(FormAction):
     def __init__(self):
@@ -171,7 +179,7 @@ class TestNavigationForm(FormAction):
         else:
             success = False
 
-        return [SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, success)]
+        return CLEARED_SLOTS + [SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, success)]
 
 
 def _get_postal_code(text: str) -> Optional[str]:

--- a/action-server/tests/actions/test_test_navigation_form.py
+++ b/action-server/tests/actions/test_test_navigation_form.py
@@ -9,6 +9,7 @@ from rasa_sdk.forms import REQUESTED_SLOT
 
 from covidflow.actions.constants import TEST_NAVIGATION_SUCCESS_SLOT
 from covidflow.actions.test_navigation_form import (
+    CLEARED_SLOTS,
     END_FORM_SLOT,
     FORM_NAME,
     INVALID_POSTAL_CODE_COUNTER_SLOT,
@@ -201,7 +202,9 @@ class TestTestNavigationForm(FormTestCase):
 
         self.run_form(tracker, DOMAIN)
 
-        self.assert_events([Form(FORM_NAME), SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT)])
+        self.assert_events(
+            [Form(FORM_NAME), SlotSet(REQUESTED_SLOT, POSTAL_CODE_SLOT),]
+        )
 
         self.assert_templates(["utter_ask_test_navigation__postal_code"])
 
@@ -265,9 +268,9 @@ class TestTestNavigationForm(FormTestCase):
         self.run_form(tracker, DOMAIN)
 
         self.assert_events(
-            [
-                SlotSet(POSTAL_CODE_SLOT, None),
-                SlotSet(END_FORM_SLOT, True),
+            [SlotSet(POSTAL_CODE_SLOT, None), SlotSet(END_FORM_SLOT, True),]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -286,9 +289,9 @@ class TestTestNavigationForm(FormTestCase):
         self.run_form(tracker, DOMAIN)
 
         self.assert_events(
-            [
-                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
-                SlotSet(END_FORM_SLOT, True),
+            [SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE), SlotSet(END_FORM_SLOT, True),]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -368,9 +371,9 @@ class TestTestNavigationForm(FormTestCase):
         self.run_form(tracker, DOMAIN)
 
         self.assert_events(
-            [
-                SlotSet(POSTAL_CODE_SLOT, None),
-                SlotSet(END_FORM_SLOT, True),
+            [SlotSet(POSTAL_CODE_SLOT, None), SlotSet(END_FORM_SLOT, True),]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -393,9 +396,9 @@ class TestTestNavigationForm(FormTestCase):
         self.run_form(tracker, DOMAIN)
 
         self.assert_events(
-            [
-                SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
-                SlotSet(END_FORM_SLOT, True),
+            [SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE), SlotSet(END_FORM_SLOT, True),]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -473,8 +476,9 @@ class TestTestNavigationForm(FormTestCase):
         self.run_form(tracker, DOMAIN)
 
         self.assert_events(
-            [
-                SlotSet(TRY_DIFFERENT_ADDRESS_SLOT, False),
+            [SlotSet(TRY_DIFFERENT_ADDRESS_SLOT, False),]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, False),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -527,6 +531,9 @@ class TestTestNavigationForm(FormTestCase):
             [
                 SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
                 SlotSet(LOCATIONS_SLOT, [TESTING_LOCATION_RAW]),
+            ]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),
@@ -558,6 +565,9 @@ class TestTestNavigationForm(FormTestCase):
             [
                 SlotSet(POSTAL_CODE_SLOT, POSTAL_CODE),
                 SlotSet(LOCATIONS_SLOT, [TESTING_LOCATION_RAW, TESTING_LOCATION_RAW]),
+            ]
+            + CLEARED_SLOTS
+            + [
                 SlotSet(TEST_NAVIGATION_SUCCESS_SLOT, True),
                 Form(None),
                 SlotSet(REQUESTED_SLOT, None),


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Clear all slots (except featurized test_navigation_success slot) at submit. Clearing them at the beginning of the form (in `form._activate_if_required`, that we use to display intro messages) doesn't work if done cleanly because validation of already present slots takes place before slot values can be erased, and there is a lot of logic and messages in the validation.

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #341

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
