### PR TITLE
chore(messages): adjust to allow toggling text field (#344)

### DIFF
--- a/action-server/covidflow/actions/action_goodbye.py
+++ b/action-server/covidflow/actions/action_goodbye.py
@@ -4,7 +4,6 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ConversationPaused
 from rasa_sdk.executor import CollectingDispatcher
 
-from .constants import END_CONVERSATION_MESSAGE
 from .lib.log_util import bind_logger
 
 ACTION_NAME = "action_goodbye"
@@ -22,7 +21,5 @@ class ActionGoodbye(Action):
     ) -> List[Dict[Text, Any]]:
         bind_logger(tracker)
         dispatcher.utter_message(template="utter_goodbye")
-
-        dispatcher.utter_message(json_message=END_CONVERSATION_MESSAGE)
 
         return [ConversationPaused()]

--- a/action-server/covidflow/actions/action_qa_goodbye.py
+++ b/action-server/covidflow/actions/action_qa_goodbye.py
@@ -4,7 +4,7 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ConversationPaused
 from rasa_sdk.executor import CollectingDispatcher
 
-from .constants import CANCEL_CI_SLOT, END_CONVERSATION_MESSAGE
+from .constants import CANCEL_CI_SLOT
 from .lib.log_util import bind_logger
 
 
@@ -25,7 +25,5 @@ class ActionQaGoodbye(Action):
             )
 
         dispatcher.utter_message(template="utter_goodbye")
-
-        dispatcher.utter_message(json_message=END_CONVERSATION_MESSAGE)
 
         return [ConversationPaused()]

--- a/action-server/tests/actions/test_action_goodbye.py
+++ b/action-server/tests/actions/test_action_goodbye.py
@@ -1,7 +1,6 @@
 from rasa_sdk.events import ConversationPaused
 
 from covidflow.actions.action_goodbye import ActionGoodbye
-from covidflow.actions.constants import END_CONVERSATION_MESSAGE
 
 from .action_test_helper import ActionTestCase
 
@@ -18,6 +17,4 @@ class ActionGoodbyeTest(ActionTestCase):
 
         self.assert_events([ConversationPaused()])
 
-        self.assert_templates(["utter_goodbye", None])
-
-        self.assert_json_messages([{}, END_CONVERSATION_MESSAGE])
+        self.assert_templates(["utter_goodbye"])

--- a/action-server/tests/actions/test_action_qa_goodbye.py
+++ b/action-server/tests/actions/test_action_qa_goodbye.py
@@ -1,7 +1,7 @@
 from rasa_sdk.events import ConversationPaused
 
 from covidflow.actions.action_qa_goodbye import ActionQaGoodbye
-from covidflow.actions.constants import CANCEL_CI_SLOT, END_CONVERSATION_MESSAGE
+from covidflow.actions.constants import CANCEL_CI_SLOT
 
 from .action_test_helper import ActionTestCase
 
@@ -18,9 +18,7 @@ class ActionQAGoodbyeTest(ActionTestCase):
 
         self.assert_events([ConversationPaused()])
 
-        self.assert_templates(["utter_goodbye", None])
-
-        self.assert_json_messages([{}, END_CONVERSATION_MESSAGE])
+        self.assert_templates(["utter_goodbye"])
 
     def test_cancel_ci_false(self):
         tracker = self.create_tracker(slots={CANCEL_CI_SLOT: False})
@@ -30,7 +28,5 @@ class ActionQAGoodbyeTest(ActionTestCase):
         self.assert_events([ConversationPaused()])
 
         self.assert_templates(
-            ["utter_daily_ci__qa__will_contact_tomorrow", "utter_goodbye", None]
+            ["utter_daily_ci__qa__will_contact_tomorrow", "utter_goodbye"]
         )
-
-        self.assert_json_messages([{}, {}, END_CONVERSATION_MESSAGE])

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -24,6 +24,9 @@ responses:
           payload: "/ask_question"
         - title: "I’d like to know where to get tested"
           payload: "/navigate_test_locations"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_assessment_entry:
     - text: OK, let’s assess your symptoms to see how you’re doing and which steps you should take. Let’s get started!
@@ -38,6 +41,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_severe_symptoms_recommendations_1:
     - text: These symptoms require immediate response, so please call 911 immediately, or go to your nearest emergency department
@@ -61,6 +67,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_moderate_symptoms:
     - text: "Now, do you have any, or a combination of, the following: mild to moderate shortness of breath, inability to lie down because of difficulty breathing, chronic health conditions that you are having difficulty managing because of difficulty breathing, or sudden loss of taste or smell?"
@@ -72,6 +81,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_no_moderate_symptoms:
     - text: OK, it seems that you don’t have symptoms that require immediate medical assistance. Let’s continue your assessment
@@ -96,6 +108,9 @@ responses:
 
   utter_goodbye:
     - text: "Thanks and take care of yourself!"
+      custom:
+        data:
+          disableTextField: "true"
 
   # Mild symptoms flow
 
@@ -109,6 +124,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_monitor_symptoms_changes:
     - text: "Please monitor your symptoms for any changes or in case you get new symptoms, or if they worsen"
@@ -123,6 +141,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_travel:
     - text: "Have you traveled in any country outside of Canada within the last 14 days (including passing through an airport)?"
@@ -134,6 +155,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_probably_not_covid:
     - text: In this case, you probably don’t have Covid-19
@@ -180,6 +204,9 @@ responses:
           payload: '/inform{"province": "nt"}'
         - title: NU
           payload: '/inform{"province": "nu"}'
+      custom:
+        data:
+          disableTextField: "true"
 
   provincial_811_mb:
     - text: "1-866-999-9698 option 4 or 1-888-315-9257 in the Winnipeg area"
@@ -248,6 +275,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   ## Tested positive
 
@@ -270,6 +300,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_tested_positive_no_symptoms:
     - text: "Although your test is positive, it looks like you’re not experiencing any significant symptoms at the moment"
@@ -281,6 +314,9 @@ responses:
           payload: "/more"
         - title: "Less than 14 days ago"
           payload: "/less"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_when_tested_less_14_recommendation:
     - text: In this case, I suggest you monitor your condition for any changes
@@ -312,6 +348,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__start_enroll:
     - text: Great! So that I can follow up with you daily and provide personalized recommendations, I need to ask you a few questions
@@ -341,6 +380,9 @@ responses:
           payload: "/affirm"
         - title: No I want to enroll
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__ok_continue:
     - text: "OK, let’s continue!"
@@ -385,6 +427,9 @@ responses:
           payload: "/resend_code"
         - title: Re-enter my number
           payload: "/reenter_phone_number"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_phone_number_new:
     - text: OK, please enter your mobile phone number, so that I can reach you
@@ -398,6 +443,9 @@ responses:
           payload: "/deny"
         - title: What are pre-existing conditions?
           payload: "/help_preconditions"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_explain_preconditions:
     - text: You may be more at risk if you have underlying medical conditions (e.g. heart disease, hypertension, diabetes, chronic respiratory disease, cancer) or if your immune system is compromised from a medical condition or treatment (e.g. chemotherapy)
@@ -411,6 +459,9 @@ responses:
           payload: "/deny"
         - title: I don't know
           payload: "/dont_know"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__note_preconditions:
     - text: If you're not sure, I will put a note in your profile that you might be at risk
@@ -425,6 +476,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__enroll_done_1:
     - text: Thanks. I have recorded all your answers in your personal profile
@@ -459,6 +513,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_contact_healthcare_professional:
     - text: In this case, you should speak to a healthcare professional to discuss your situation
@@ -479,6 +536,9 @@ responses:
           payload: "/more"
         - title: Less than 14 days ago
           payload: "/less"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_social_distancing_leave_home:
     - text: OK, you should keep complying with social distancing rules, and if you leave your home, I recommend that you wear a mask
@@ -497,6 +557,9 @@ responses:
           payload: /navigate_test_locations
         - title: No thanks
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_anything_else_without_test_navigation:
     - text: "Is there anything else I can help you with?"
@@ -505,6 +568,9 @@ responses:
           payload: "/ask_question"
         - title: No thanks
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_can_help_with_questions:
     - text: "I can help answer your questions about Covid-19, on many different topics"
@@ -629,6 +695,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_post_feedback:
     - text: "Got it, sorry about that! I’m still learning so your feedback helps me improve and provide better answers"
@@ -643,6 +712,9 @@ responses:
           payload: "/get_assessment"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_try_again_later:
     - text: "Please try again later if you have questions"
@@ -660,6 +732,9 @@ responses:
           payload: "/get_assessment"
         - title: No I'm done
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_assess_to_answer_offer_question:
     - text: "Do you want me to assess your symptoms?"
@@ -670,6 +745,9 @@ responses:
           payload: "/done"
         - title: No ask another question
           payload: "/ask_question"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_need_assessment_already_done:
     - text: It seems that to answer your question, I would need to assess your symptoms. However, we have already done that
@@ -686,6 +764,9 @@ responses:
           payload: "/get_assessment"
         - title: "I'm done"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_other_questions_after_answer:
     - text: "Do you have another question?"
@@ -694,6 +775,9 @@ responses:
           payload: "/ask_question"
         - title: "No I'm done"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_another_question_assessment_done:
     - text: "Would you like to ask another question?"
@@ -702,6 +786,9 @@ responses:
           payload: "/ask_question"
         - title: "No I'm done"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_another_question_no_assessment:
     - text: "Would you like to ask another question?"
@@ -712,6 +799,9 @@ responses:
           payload: "/get_assessment"
         - title: "No I'm done"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__qa__will_contact_tomorrow:
     - text: I will get in touch with you tomorrow for your daily check-in
@@ -743,6 +833,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_dont_leave_home:
     - text: "In this case, I recommend that you don’t leave your home unless you have a doctor’s appointment, or if you need to go to the hospital"
@@ -771,6 +864,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_remind_delivery_services:
     - text: "Don’t forget that most pharmacies and many grocery stores offer delivery services. Check with your local pharmacy or grocery store if they deliver"
@@ -807,6 +903,9 @@ responses:
           payload: "/worse"
         - title: No change
           payload: "/no_change"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__acknowledge_fever:
     - text: OK, I'm taking note that you have a fever today
@@ -838,6 +937,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_severe_symptoms:
     - text: OK, now, let's check your symptoms
@@ -852,6 +954,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_fever:
     - text: OK, I'm taking note that you don't have a fever today
@@ -866,6 +971,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_diff_breathing:
     - text: That's good
@@ -880,6 +988,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__no_cough_recommendation:
     - text: But since you're still feeling sick, you should keep staying isolated and continue to rest
@@ -894,6 +1005,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_1:
     - text: You may want to discuss your situation with your doctor, if that's possible, or call {provincial_811}
@@ -919,6 +1033,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_no_change__acknowledge_no_fever:
     - text: That's good, I'm taking note that you don't have a fever today
@@ -933,6 +1050,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_no_change__has_diff_breathing:
     - text: Do you still have shortness of breath or difficulty breathing?
@@ -944,6 +1064,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_no_change__acknowledge_diff_breathing:
     - text: I'm sorry to see that
@@ -975,6 +1098,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_better__acknowledge_no_fever:
     - text: That's good, I'm taking note that you don't have a fever today
@@ -989,6 +1115,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__has_diff_breathing:
     - text: Do you still have other symptoms, like shortness of breath or some difficulty breathing?
@@ -1000,6 +1129,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__has_other_mild_symptoms_with_acknowledge:
     - text: Good, and do you still have symptoms like fatigue or sore throat?
@@ -1014,6 +1146,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__is_symptom_free:
     - text: Great, would you say that you are symptom-free, or do you still feel a little sick?
@@ -1022,6 +1157,9 @@ responses:
           payload: "/symptom_free"
         - title: Still sick
           payload: "/still_sick"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_better__breathing_difficulty_recommendation_1:
     - text: Sorry about that. If this gets worse, I recommend that you contact your doctor or call {provincial_811} to discuss your symptoms
@@ -1050,6 +1188,9 @@ responses:
           payload: "/continue"
         - title: Cancel
           payload: "/cancel"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__keep_or_cancel__acknowledge_continue_ci:
     - text: Sure, I'll continue checking in on you daily
@@ -1067,6 +1208,9 @@ responses:
           payload: "/continue"
         - title: No cancel daily check-in
           payload: "/cancel"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__keep_or_cancel__feel_worse_keep_ci:
     - text: Since you're feeling worse, I will make sure to check-in on you tomorrow
@@ -1106,6 +1250,9 @@ responses:
           payload: "/opt_out"
         - title: Continue
           payload: "/continue"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__early_opt_out__acknowledge_continue_ci:
     - text: OK, let's continue
@@ -1131,6 +1278,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_checkin__invalid_id__anything_else:
     - text: "OK, is there anything else I can help you with?"
@@ -1139,6 +1289,9 @@ responses:
           payload: "/ask_question"
         - title: No I'm done
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_checkin__invalid_id__visit_dialogue:
     - text: At any time, you can visit [our website](https://covid19.dialogue.co/) for information, or to get a self-assessment
@@ -1168,6 +1321,9 @@ responses:
           payload: /get_assessment
         - title: No but I have other questions
           payload: /ask_question
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_test_navigation__continue_assessment_done:
     - text: Do you want to continue and search for a testing site?
@@ -1178,6 +1334,9 @@ responses:
           payload: /later
         - title: No but I have other questions
           payload: /ask_question
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__come_back:
     - text: OK, when you’re ready, come back here (https://covid19.dialogue.co/#/chat) and I’ll help you
@@ -1276,6 +1435,9 @@ responses:
           payload: "/affirm"
         - title: No
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__acknowledge:
     - text: OK
@@ -1289,6 +1451,9 @@ responses:
           payload: /ask_question
         - title: I’m done
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__what_next_assessment_done:
     - text: What else may I help you with?
@@ -1297,6 +1462,9 @@ responses:
           payload: /ask_question
         - title: I’m done
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__anything_else_no_assessment:
     - text: May I help you with anything else?
@@ -1307,6 +1475,9 @@ responses:
           payload: /ask_question
         - title: No I’m done
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__anything_else_assessment_done:
     - text: May I help you with anything else?
@@ -1315,3 +1486,6 @@ responses:
           payload: /ask_question
         - title: No I’m done
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -24,6 +24,9 @@ responses:
           payload: "/ask_question"
         - title: "J’aimerais savoir où je peux me faire tester"
           payload: "/navigate_test_locations"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_assessment_entry:
     - text: Entendu, je vais évaluer vos symptômes afin de vous fournir des recommandations adaptées à votre situation. Allons-y!
@@ -38,6 +41,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_has_fever:
     - text: Faites-vous de la fièvre (plus de 38°C ou 100,4°F)?
@@ -49,6 +55,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_severe_symptoms_recommendations_1:
     - text: Ces symptômes exigent une attention immédiate. Vous devriez appeler le 911 immédiatement ou vous rendre directement au service d’urgence le plus proche
@@ -72,6 +81,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_no_moderate_symptoms:
     - text: Très bien, il semble que vous n’avez pas de symptômes qui requièrent une assistance médicale immédiate. Continuons votre évaluation
@@ -92,6 +104,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_remind_stay_home_self_isolate:
     - text: "Veuillez vous assurer de rester à la maison et de vous isoler pendant au moins 14 jours"
@@ -107,6 +122,9 @@ responses:
 
   utter_goodbye:
     - text: "Merci, et prenez bien soin de vous!"
+      custom:
+        data:
+          disableTextField: "true"
 
   # Mild symptoms flow
 
@@ -120,6 +138,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_monitor_symptoms_changes:
     - text: "Veuillez suivre l'évolution de vos symptômes et notez tout changement, en particulier si vous développez de nouveaux symptômes ou s'ils empirent"
@@ -134,6 +155,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_travel:
     - text: "Avez-vous voyagé à l'extérieur du Canada durant les 14 derniers jours (Ceci inclut le passage dans un aéroport étranger)?"
@@ -145,6 +169,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_probably_not_covid:
     - text: Dans ce cas, vous n'avez probablement pas la Covid-19
@@ -191,6 +218,9 @@ responses:
           payload: '/inform{"province": "nt"}'
         - title: NU
           payload: '/inform{"province": "nu"}'
+      custom:
+        data:
+          disableTextField: "true"
 
   provincial_811_mb:
     - text: "1-866-999-9698 option 4 ou 1-888-315-9257 dans la région de Winnipeg"
@@ -259,6 +289,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   ## Tested positive
 
@@ -281,6 +314,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_tested_positive_no_symptoms:
     - text: "Bien que votre test soit positif, il semble que vous ne présentiez pas de symptômes pour le moment"
@@ -292,6 +328,9 @@ responses:
           payload: "/more"
         - title: "Il y a 14 jours ou moins"
           payload: "/less"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_when_tested_less_14_recommendation:
     - text: Dans ce cas, je vous recommande de surveiller vos symptômes pour tout changement
@@ -341,6 +380,9 @@ responses:
           payload: "/affirm"
         - title: Non je veux m’inscrire
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__ok_continue:
     - text: "D’accord, continuons!"
@@ -385,6 +427,9 @@ responses:
           payload: "/resend_code"
         - title: Redonner mon numéro
           payload: "/reenter_phone_number"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_phone_number_new:
     - text: D’accord, veuillez inscrire votre numéro de téléphone, pour que je puisse vous joindre
@@ -398,6 +443,9 @@ responses:
           payload: "/deny"
         - title: Avez-vous des exemples?
           payload: "/help_preconditions"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_explain_preconditions:
     - text: "Vous pourriez être plus à risque si vous avez certains problèmes médicaux (par ex.: problèmes cardiaques, hypertension, diabète, maladie respiratoire chronique, cancer) ou si votre système immunitaire est affaibli en raison d'une condition ou d'un traitement médical (par ex.: chimiothérapie)"
@@ -411,6 +459,9 @@ responses:
           payload: "/deny"
         - title: Je ne sais pas
           payload: "/dont_know"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__note_preconditions:
     - text: Si vous ne savez pas, je vais mettre une note à votre profil indiquant que vous pourriez être à risque
@@ -425,6 +476,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci_enroll__enroll_done_1:
     - text: Merci. J'ai enregistré toutes vos réponses dans votre profil personnel
@@ -459,6 +513,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_contact_healthcare_professional:
     - text: Dans ce cas, vous devriez discuter de votre situation avec un professionnel de la santé
@@ -479,6 +536,9 @@ responses:
           payload: "/more"
         - title: Il y a moins de 14 jours
           payload: "/less"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_social_distancing_leave_home:
     - text: D'accord. Assurez-vous de suivre les consignes de distanciation sociale, et si vous devez sortir, je vous recommande de porter un masque
@@ -497,6 +557,9 @@ responses:
           payload: "/navigate_test_locations"
         - title: Non merci
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_anything_else_without_test_navigation:
     - text: "Puis-je faire autre chose pour vous aider?"
@@ -505,6 +568,9 @@ responses:
           payload: "/ask_question"
         - title: Non merci
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_can_help_with_questions:
     - text: "Je peux répondre à vos questions sur une variété de sujets entourant la Covid-19"
@@ -635,6 +701,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_post_feedback:
     - text: "Je suis désolée, c'est noté! J'apprends constamment, alors votre opinion me permettra de m'améliorer et de vous donner de meilleurs réponses"
@@ -649,6 +718,9 @@ responses:
           payload: "/get_assessment"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_try_again_later:
     - text: "Veuillez essayer de poser vos questions un peu plus tard"
@@ -666,6 +738,9 @@ responses:
           payload: "/get_assessment"
         - title: Non j'ai terminé
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_assess_to_answer_offer_question:
     - text: "Voulez-vous que j’évalue vos symptômes?"
@@ -676,6 +751,9 @@ responses:
           payload: "/done"
         - title: Non poser une autre question
           payload: "/ask_question"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_need_assessment_already_done:
     - text: "Il semble que pour répondre à votre question, j’aurais besoin d’évaluer vos symptômes. Or, c’est ce que nous venons de faire"
@@ -692,6 +770,9 @@ responses:
           payload: "/get_assessment"
         - title: "J'ai terminé"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_other_questions_after_answer:
     - text: "Avez-vous d'autres questions?"
@@ -700,6 +781,9 @@ responses:
           payload: "/ask_question"
         - title: "Non j'ai terminé"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_another_question_assessment_done:
     - text: "Aimeriez-vous poser une autre question?"
@@ -708,6 +792,9 @@ responses:
           payload: "/ask_question"
         - title: "Non j'ai terminé"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_another_question_no_assessment:
     - text: "Aimeriez-vous poser une autre question?"
@@ -718,6 +805,9 @@ responses:
           payload: /get_assessment
         - title: "Non j'ai terminé"
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__qa__will_contact_tomorrow:
     - text: Je vais communiquer avec vous demain pour votre suivi quotidien
@@ -749,6 +839,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_dont_leave_home:
     - text: "Dans ce cas, je vous conseille de ne pas quitter votre domicile, à part si vous avez un rendez-vous chez le médecin, ou si vous devez vous rendre à l’hôpital"
@@ -777,6 +870,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_remind_delivery_services:
     - text: "N’oubliez pas que la plupart des pharmacies et plusieurs épiceries offrent la livraison. Renseignez-vous auprès de votre pharmacie ou de votre épicerie pour savoir s’ils offrent ce service"
@@ -813,6 +909,9 @@ responses:
           payload: "/worse"
         - title: Du pareil au même
           payload: "/no_change"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__acknowledge_fever:
     - text: Entendu, je note que vous faites de la fièvre aujourd'hui
@@ -844,6 +943,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_severe_symptoms:
     - text: D'accord, voyons voir vos symptômes
@@ -858,6 +960,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_fever:
     - text: D'accord, je note que vous ne faites pas de fièvre aujourd'hui
@@ -872,6 +977,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__acknowledge_no_diff_breathing:
     - text: Tant mieux
@@ -886,6 +994,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__no_cough_recommendation:
     - text: Mais puisque vous vous sentez encore malade, je vous conseille de continuer à vous isoler et à vous reposer
@@ -900,6 +1011,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_worse__diff_breathing_worsened_recommendation_1:
     - text: Vous devriez peut-être en discuter avec votre médecin, si c'est possible, ou appeler au {provincial_811}
@@ -925,6 +1039,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_no_change__acknowledge_no_fever:
     - text: Très bien, je note que vous ne faites pas de fièvre aujourd'hui
@@ -939,6 +1056,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_no_change__has_diff_breathing:
     - text: Avez-vous encore de l'essoufflement ou de la difficulté à respirer?
@@ -950,6 +1070,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_no_change__acknowledge_diff_breathing:
     - text: Je suis désolée que ce soit encore le cas
@@ -981,6 +1104,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_better__acknowledge_no_fever:
     - text: Très bien, je note que vous ne faites pas de fièvre aujourd'hui
@@ -995,6 +1121,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__has_diff_breathing:
     - text: Avez-vous encore d'autres symptômes, comme de l'essoufflement ou de la difficulté à respirer?
@@ -1009,6 +1138,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__has_other_mild_symptoms:
     - text: Avez-vous encore d'autres symptômes, comme des maux de gorge ou de la fatigue inhabituelle?
@@ -1020,6 +1152,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_ci__feel_better__is_symptom_free:
     - text: Bonne nouvelle! Vous sentez-vous encore un peu malade, ou est-ce que vous n'avez plus de symptômes du tout?
@@ -1028,6 +1163,9 @@ responses:
           payload: "/symptom_free"
         - title: Encore malade
           payload: "/still_sick"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__feel_better__breathing_difficulty_recommendation_1:
     - text: Désolée de l'apprendre. Si cela empire, je vous conseille de contacter votre médecin, si c'est possible, ou d'appeler le {provincial_811} pour discuter de vos symptômes
@@ -1056,6 +1194,9 @@ responses:
           payload: "/continue"
         - title: Annuler
           payload: "/cancel"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__keep_or_cancel__acknowledge_continue_ci:
     - text: Parfait, je vais continuer à faire votre suivi quotidien
@@ -1073,6 +1214,9 @@ responses:
           payload: "/continue"
         - title: Non annuler le suivi
           payload: "/cancel"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__keep_or_cancel__feel_worse_keep_ci:
     - text: Puisque vous vous sentez moins bien qu'hier, je vais m'assurer de faire le suivi avec vous demain
@@ -1112,6 +1256,9 @@ responses:
           payload: "/opt_out"
         - title: Continuer
           payload: "/continue"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_ci__early_opt_out__acknowledge_continue_ci:
     - text: D'accord, continuons
@@ -1137,6 +1284,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_daily_checkin__invalid_id__anything_else:
     - text: "D'accord, puis-je faire autre chose pour vous aider?"
@@ -1145,6 +1295,9 @@ responses:
           payload: "/ask_question"
         - title: Non j'ai terminé
           payload: "/done"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_daily_checkin__invalid_id__visit_dialogue:
     - text: À tout moment, vous pouvez consultez [notre site](https://covid19.dialogue.co/) pour des informations, ou pour une auto-évaluation de vos symptômes
@@ -1174,6 +1327,9 @@ responses:
           payload: /get_assessment
         - title: Non mais j’ai d’autres questions
           payload: /ask_question
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_ask_test_navigation__continue_assessment_done:
     - text: Voulez-vous que je cherche des cliniques de dépistage maintenant?
@@ -1184,6 +1340,9 @@ responses:
           payload: /later
         - title: Non mais j’ai d’autres questions
           payload: /ask_question
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__come_back:
     - text: D’accord. Quand vous serez prêt(e), revenez me voir (https://covid19.dialogue.co/#/chat) et je pourrai vous aider
@@ -1282,6 +1441,9 @@ responses:
           payload: "/affirm"
         - title: Non
           payload: "/deny"
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__acknowledge:
     - text: D'accord
@@ -1295,6 +1457,9 @@ responses:
           payload: /ask_question
         - title: J’ai terminé
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__what_next_assessment_done:
     - text: Que puis-je faire d’autre pour vous aider?
@@ -1303,6 +1468,9 @@ responses:
           payload: /ask_question
         - title: J’ai terminé
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__anything_else_no_assessment:
     - text: Puis-je faire autre chose pour vous aider?
@@ -1313,6 +1481,9 @@ responses:
           payload: /ask_question
         - title: Non j’ai terminé
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"
 
   utter_test_navigation__anything_else_assessment_done:
     - text: Puis-je faire autre chose pour vous aider?
@@ -1321,3 +1492,6 @@ responses:
           payload: /ask_question
         - title: Non j’ai terminé
           payload: /done
+      custom:
+        data:
+          disableTextField: "true"

--- a/integration-tests-fr/config.ini
+++ b/integration-tests-fr/config.ini
@@ -1,5 +1,5 @@
 [runner]
-ignored_result_keys = sender,recipient_id
+ignored_result_keys = sender,recipient_id,custom,attachment
 
 [protocol]
 type = rest


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Added the field to all messages with buttons
Validate in domain validation that text field is disabled for the same messages

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #344
needs https://github.com/dialoguemd/covid-19/issues/756

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
