### PR TITLE
Feat make feedback non mandatory (#343)

### DIFF
--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -627,7 +627,6 @@
   - utter_please_visit_again
   - action_qa_goodbye
 
-
 ## QA - success - assessment after
 * greet{"metadata":{}}
   - action_greeting_messages

--- a/integration-tests-en/interactions/user/q_and_a/submit_question.jinja
+++ b/integration-tests-en/interactions/user/q_and_a/submit_question.jinja
@@ -1,3 +1,3 @@
 {
-	"message": "This is my question"
+	"message": "Can I get coronavirus from my cat?"
 }

--- a/integration-tests-en/scenarios/q_and_a/entry_success_no_feedback.yml
+++ b/integration-tests-en/scenarios/q_and_a/entry_success_no_feedback.yml
@@ -1,0 +1,10 @@
+- user: q_and_a/greet_profile_success
+  bot: welcome
+- user: ask_question
+  bot: q_and_a/entry_first_time
+- user: q_and_a/submit_question
+  bot: q_and_a/success
+- user: q_and_a/submit_question
+  bot: q_and_a/success
+- user: navigate_tests
+  bot: test_navigation/explanations


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
If we ask for feedback and receive something else, we artificially bring the dialogue to the point it would be if feedback was given and we had asked if the user had another question, replaying the user input to the dialogue.

This part of the logic could have been simpler and cleaner in the stories, but getting the feedback slot out of the form would have brought its lot of complications, so all in all this was the simplest way


## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
closes #343

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->
https://github.com/dialoguemd/covidflow/pull/346 has to be merged before

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
