### PR TITLE
feat(flow): add nlu to remaining questions

### DIFF
--- a/core/core/policies/unsupported_intent_policy.py
+++ b/core/core/policies/unsupported_intent_policy.py
@@ -56,6 +56,9 @@ SUPPORTED_INTENTS_BY_ACTION = {
     "utter_ask_anything_else_with_test_navigation": MAIN_INTENTS + AFFIRM_DENY_INTENTS,
     "utter_ask_anything_else_without_test_navigation": MAIN_INTENTS
     + AFFIRM_DENY_INTENTS,
+    "utter_ask_daily_ci__feel": ["better", "worse", "no_change"],
+    "utter_ask_when_tested": AFFIRM_DENY_INTENTS,
+    "utter_ask_when_first_symptoms": AFFIRM_DENY_INTENTS,
 }
 
 FALLBACK_INTENT = "fallback"

--- a/core/data/stories.md
+++ b/core/data/stories.md
@@ -299,7 +299,7 @@
   - slot{"symptoms": "none"}
   - action_tested_positive_no_symptoms_recommendations
   - utter_ask_when_tested
-* less
+* deny
   - utter_when_tested_less_14_recommendation
   - daily_ci_enroll_form
   - form{"name": "daily_ci_enroll_form"}
@@ -319,7 +319,7 @@
   - utter_try_again_later
   - action_qa_goodbye
 
-## tested positive - no symptoms tested less than 14 days
+## tested positive - no symptoms tested less than 14 days error
 * tested_positive
   - tested_positive_form
   - form{"name": "tested_positive_form"}
@@ -328,7 +328,9 @@
   - slot{"symptoms": "none"}
   - action_tested_positive_no_symptoms_recommendations
   - utter_ask_when_tested
-* less
+* fallback
+  - utter_ask_when_tested_error
+* deny
   - utter_when_tested_less_14_recommendation
   - daily_ci_enroll_form
   - form{"name": "daily_ci_enroll_form"}
@@ -351,7 +353,24 @@
   - slot{"symptoms": "none"}
   - action_tested_positive_no_symptoms_recommendations
   - utter_ask_when_tested
-* more
+* affirm
+  - action_tested_positive_maybe_cured_final_recommendations
+  - utter_ask_anything_else_without_test_navigation
+* done OR deny
+  - action_goodbye
+
+## tested positive - cured - error
+* tested_positive
+  - tested_positive_form
+  - form{"name": "tested_positive_form"}
+  - form{"name": null}
+  - slot{"self_assess_done": true}
+  - slot{"symptoms": "none"}
+  - action_tested_positive_no_symptoms_recommendations
+  - utter_ask_when_tested
+* fallback
+  - utter_ask_when_tested_error
+* affirm
   - action_tested_positive_maybe_cured_final_recommendations
   - utter_ask_anything_else_without_test_navigation
 * ask_question OR affirm OR fallback
@@ -489,11 +508,36 @@
   - slot{"symptoms": "none"}
   - utter_returning_no_symptoms
   - utter_ask_when_first_symptoms
-* more
+* affirm
   - utter_social_distancing_leave_home
   - utter_ask_anything_else_without_test_navigation
 * done OR deny
   - action_goodbye
+
+## return for check-in - no symptoms - first symptoms >= 14 days ago error
+* checkin_return
+  - checkin_return_form
+  - form{"name": "checkin_return_form"}
+  - form{"name": null}
+  - slot{"self_assess_done": true}
+  - slot{"symptoms": "none"}
+  - utter_returning_no_symptoms
+  - utter_ask_when_first_symptoms
+* fallback
+  - utter_ask_when_first_symptoms_error
+* affirm
+  - utter_social_distancing_leave_home
+  - utter_ask_anything_else_without_test_navigation
+* ask_question OR affirm OR fallback
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_cant_answer
+  - utter_ask_different_question
+* done OR deny
+  - utter_please_visit_again
+  - action_qa_goodbye
 
 ## return for check-in - no symptoms - first symptoms < 14 days ago
 * checkin_return
@@ -504,7 +548,7 @@
   - slot{"symptoms": "none"}
   - utter_returning_no_symptoms
   - utter_ask_when_first_symptoms
-* less
+* deny
   - utter_self_isolate_symptom_free
   - utter_ask_anything_else_without_test_navigation
 * ask_question OR affirm OR fallback
@@ -515,6 +559,23 @@
   - utter_question_answering_error
   - utter_try_again_later
   - action_qa_goodbye
+
+## return for check-in - no symptoms - first symptoms < 14 days ago error
+* checkin_return
+  - checkin_return_form
+  - form{"name": "checkin_return_form"}
+  - form{"name": null}
+  - slot{"self_assess_done": true}
+  - slot{"symptoms": "none"}
+  - utter_returning_no_symptoms
+  - utter_ask_when_first_symptoms
+* fallback
+  - utter_ask_when_first_symptoms_error
+* deny
+  - utter_self_isolate_symptom_free
+  - utter_ask_anything_else_without_test_navigation
+* done OR deny
+  - action_goodbye
 
 ## QA - failure - no assessment after
 * greet{"metadata":{}}
@@ -804,9 +865,27 @@
   - action_initialize_daily_checkin
   - utter_daily_ci__greet
   - utter_ask_daily_ci__early_opt_out__continue_ci
-* continue OR affirm
+* continue
   - utter_daily_ci__early_opt_out__acknowledge_continue_ci
   - utter_ask_daily_ci__feel
+* worse
+  - daily_ci_feel_worse_form
+  - form{"name": "daily_ci_feel_worse_form"}
+  - form{"name": null}
+  - slot{"symptoms": "severe"}
+  - slot{"self_assess_done": true}
+  - action_severe_symptoms_recommendations
+
+## daily check-in - feel worse - error - severe symptoms
+* daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
+  - utter_daily_ci__greet
+  - utter_ask_daily_ci__early_opt_out__continue_ci
+* continue
+  - utter_daily_ci__early_opt_out__acknowledge_continue_ci
+  - utter_ask_daily_ci__feel
+* fallback
+  - utter_ask_daily_ci__feel_error
 * worse
   - daily_ci_feel_worse_form
   - form{"name": "daily_ci_feel_worse_form"}
@@ -967,6 +1046,29 @@
   - utter_please_visit_again
   - action_qa_goodbye
 
+## daily check-in - feel no change - error - mild symptoms
+* daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
+  - utter_daily_ci__greet
+  - utter_ask_daily_ci__early_opt_out__continue_ci
+* continue
+  - utter_daily_ci__early_opt_out__acknowledge_continue_ci
+  - utter_ask_daily_ci__feel
+* fallback
+  - utter_ask_daily_ci__feel_error
+* no_change
+  - daily_ci_feel_no_change_form
+  - form{"name": "daily_ci_feel_no_change_form"}
+  - form{"name": null}
+  - slot{"symptoms": "mild"}
+  - slot{"self_assess_done": true}
+  - daily_ci_keep_or_cancel_form
+  - form{"name": "daily_ci_keep_or_cancel_form"}
+  - form{"name": null}
+  - utter_ask_anything_else_with_test_navigation
+* done OR deny
+  - action_goodbye
+
 ## daily check-in - feel no change - no symptoms
 * daily_checkin{"metadata":{}}
   - action_initialize_daily_checkin
@@ -1069,6 +1171,37 @@
   - slot{"question_answering_status": "failure"}
   - utter_question_answering_error
   - utter_try_again_later
+  - action_qa_goodbye
+
+## daily check-in - feel better - error - no symptoms
+* daily_checkin{"metadata":{}}
+  - action_initialize_daily_checkin
+  - utter_daily_ci__greet
+  - utter_ask_daily_ci__early_opt_out__continue_ci
+* continue
+  - utter_daily_ci__early_opt_out__acknowledge_continue_ci
+  - utter_ask_daily_ci__feel
+* fallback
+  - utter_ask_daily_ci__feel_error
+* better
+  - daily_ci_feel_better_form
+  - form{"name": "daily_ci_feel_better_form"}
+  - form{"name": null}
+  - slot{"symptoms": "none"}
+  - slot{"self_assess_done": true}
+  - daily_ci_keep_or_cancel_form
+  - form{"name": "daily_ci_keep_or_cancel_form"}
+  - form{"name": null}
+  - utter_ask_anything_else_without_test_navigation
+* ask_question OR affirm OR fallback
+  - question_answering_form
+  - form{"name": "question_answering_form"}
+  - form{"name": null}
+  - slot{"question_answering_status": "out_of_distribution"}
+  - utter_cant_answer
+  - utter_ask_different_question
+* done OR deny
+  - utter_please_visit_again
   - action_qa_goodbye
 
 ## daily check-in - invalid ID - nothing else

--- a/core/domain/domain.core.yml
+++ b/core/domain/domain.core.yml
@@ -10,8 +10,6 @@ intents:
   - tested_positive
   - ask_question
   - inform
-  - less
-  - more
   - help_preconditions
   - done
   - better
@@ -199,6 +197,9 @@ slots:
     type: bool
 
   checkin_return__moderate_symptoms_worsened:
+    type: unfeaturized
+
+  tested_positive__mild_symptoms_worsened:
     type: unfeaturized
 
   daily_ci_enroll__do_enroll:

--- a/core/domain/domain.en.yml
+++ b/core/domain/domain.en.yml
@@ -314,12 +314,15 @@ responses:
     - text: "Although your test is positive, it looks like you’re not experiencing any significant symptoms at the moment"
 
   utter_ask_when_tested:
-    - text: "When have you been diagnosed?"
+    - text: Have you been diagnosed more than 14 days ago?
+
+  utter_ask_when_tested_error:
+    - text: Sorry, when have you been diagnosed?
       buttons:
         - title: "More than 14 days ago"
-          payload: "/more"
+          payload: "/affirm"
         - title: "Less than 14 days ago"
-          payload: "/less"
+          payload: "/deny"
       custom:
         data:
           disableTextField: "true"
@@ -548,12 +551,15 @@ responses:
     - text: "It looks like you’re not experiencing any significant Covid-19 symptoms"
 
   utter_ask_when_first_symptoms:
-    - text: When did you experience your first symptoms?
+    - text: Did you experience your first symptoms more than 14 days ago?
+
+  utter_ask_when_first_symptoms_error:
+    - text: Sorry, when did you experience your first symptoms?
       buttons:
         - title: More than 14 days ago
-          payload: "/more"
+          payload: "/affirm"
         - title: Less than 14 days ago
-          payload: "/less"
+          payload: "/deny"
       custom:
         data:
           disableTextField: "true"
@@ -836,7 +842,10 @@ responses:
     - text: Hello {first_name}, this is Chloe, and I'm checking in to see how you're doing today
 
   utter_ask_daily_ci__feel:
-    - text: First, compared to yesterday, how do you feel?
+    - text: First, compared to yesterday, do you feel better, worse, or the same?
+
+  utter_ask_daily_ci__feel_error:
+    - text: Sorry, please tell me how you feel compared to yesterday
       buttons:
         - title: Better
           payload: "/better"

--- a/core/domain/domain.fr.yml
+++ b/core/domain/domain.fr.yml
@@ -328,12 +328,15 @@ responses:
     - text: "Bien que votre test soit positif, il semble que vous ne présentiez pas de symptômes pour le moment"
 
   utter_ask_when_tested:
-    - text: "Quand avez-vous reçu votre diagnostic?"
+    - text: "Avez-vous reçu votre diagnostic il y a plus de 14 jours?"
+
+  utter_ask_when_tested_error:
+    - text: "Désolée, quand avez-vous reçu votre diagnostic?"
       buttons:
         - title: "Il y a plus de 14 jours"
-          payload: "/more"
+          payload: "/affirm"
         - title: "Il y a 14 jours ou moins"
-          payload: "/less"
+          payload: "/deny"
       custom:
         data:
           disableTextField: "true"
@@ -548,12 +551,15 @@ responses:
     - text: "Il semble que vous n’ayez pas de symptômes de la Covid-19"
 
   utter_ask_when_first_symptoms:
-    - text: Quand avez-vous commencé à avoir vos premiers symptômes?
+    - text: Avez-vous eu vos premiers symptômes il y a plus de 14 jours?
+
+  utter_ask_when_first_symptoms_error:
+    - text: Désolée, quand avez-vous commencé à avoir vos premiers symptômes?
       buttons:
         - title: Il y a 14 jours ou plus
-          payload: "/more"
+          payload: "/affirm"
         - title: Il y a moins de 14 jours
-          payload: "/less"
+          payload: "/deny"
       custom:
         data:
           disableTextField: "true"
@@ -842,7 +848,10 @@ responses:
     - text: Bonjour {first_name}, ici Chloé, pour votre suivi quotidien. Voyons voir comment ça va aujourd'hui
 
   utter_ask_daily_ci__feel:
-    - text: D'abord, comment vous sentez-vous par rapport à hier?
+    - text: D’abord, par rapport à hier, vous sentez-vous mieux, plus mal, ou du pareil au même?
+
+  utter_ask_daily_ci__feel_error:
+    - text: Désolée, dites-moi comment vous vous sentez par rapport à hier
       buttons:
         - title: Mieux
           payload: "/better"

--- a/integration-tests-en/interactions/bot/checkin_return/ask_when_first_symptoms.jinja
+++ b/integration-tests-en/interactions/bot/checkin_return/ask_when_first_symptoms.jinja
@@ -1,0 +1,10 @@
+{% import 'bot/macros.jinja' as bot %}
+
+[
+    {
+        "text": "It looks like you’re not experiencing any significant Covid-19 symptoms"
+    },
+    {
+        "text": "Did you experience your first symptoms more than 14 days ago?"
+    }
+]

--- a/integration-tests-en/interactions/bot/checkin_return/ask_when_first_symptoms_error.jinja
+++ b/integration-tests-en/interactions/bot/checkin_return/ask_when_first_symptoms_error.jinja
@@ -2,17 +2,14 @@
 
 [
     {
-        "text": "It looks like you’re not experiencing any significant Covid-19 symptoms"
-    },
-    {
-        "text": "When did you experience your first symptoms?",
+        "text": "Sorry, when did you experience your first symptoms?",
         "buttons": [
             {
-                "payload": "/more",
+                "payload": "/affirm",
                 "title": "More than 14 days ago"
             },
             {
-                "payload": "/less",
+                "payload": "/deny",
                 "title": "Less than 14 days ago"
             }
         ]

--- a/integration-tests-en/interactions/bot/daily_ci/ask_feel.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci/ask_feel.jinja
@@ -3,21 +3,6 @@
         "text": "OK, let's continue"
     },
     {
-        "text": "First, compared to yesterday, how do you feel?",
-        "buttons": [
-            {
-                "payload": "/better",
-                "title": "Better"
-            },
-            {
-                "payload": "/worse",
-                "title": "Worse"
-            },
-            {
-                "payload": "/no_change",
-                "title": "No change"
-            }
-        ]
-
+        "text": "First, compared to yesterday, do you feel better, worse, or the same?"
     }
 ]

--- a/integration-tests-en/interactions/bot/daily_ci/ask_feel_error.jinja
+++ b/integration-tests-en/interactions/bot/daily_ci/ask_feel_error.jinja
@@ -1,0 +1,20 @@
+[
+    {
+        "text": "Sorry, please tell me how you feel compared to yesterday",
+        "buttons": [
+            {
+                "payload": "/better",
+                "title": "Better"
+            },
+            {
+                "payload": "/worse",
+                "title": "Worse"
+            },
+            {
+                "payload": "/no_change",
+                "title": "No change"
+            }
+        ]
+
+    }
+]

--- a/integration-tests-en/interactions/bot/tested_positive/ask_when_tested.jinja
+++ b/integration-tests-en/interactions/bot/tested_positive/ask_when_tested.jinja
@@ -5,16 +5,6 @@
         "text": "Although your test is positive, it looks like you’re not experiencing any significant symptoms at the moment"
     },
     {
-        "text": "When have you been diagnosed?",
-        "buttons": [
-            {
-                "payload": "/more",
-                "title": "More than 14 days ago"
-            },
-            {
-                "payload": "/less",
-                "title": "Less than 14 days ago"
-            }
-        ]
+        "text": "Have you been diagnosed more than 14 days ago?"
     }
 ]

--- a/integration-tests-en/interactions/bot/tested_positive/ask_when_tested_error.jinja
+++ b/integration-tests-en/interactions/bot/tested_positive/ask_when_tested_error.jinja
@@ -1,0 +1,17 @@
+{% import 'bot/macros.jinja' as bot %}
+
+[
+    {
+        "text": "Sorry, when have you been diagnosed?",
+        "buttons": [
+            {
+                "payload": "/affirm",
+                "title": "More than 14 days ago"
+            },
+            {
+                "payload": "/deny",
+                "title": "Less than 14 days ago"
+            }
+        ]
+    }
+]

--- a/integration-tests-en/scenarios/checkin_return/no_symptoms_less.yml
+++ b/integration-tests-en/scenarios/checkin_return/no_symptoms_less.yml
@@ -13,8 +13,8 @@
 - user: deny
   bot: checkin_return/ask_mild_symptoms
 - user: deny
-  bot: checkin_return/ask_when_last_symptoms
-- user: less
+  bot: checkin_return/ask_when_first_symptoms
+- user: deny
   bot: checkin_return/ask_anything_else_no_symptoms_less
 - user: done
   bot: thank_you_take_care

--- a/integration-tests-en/scenarios/checkin_return/no_symptoms_more_with_error.yml
+++ b/integration-tests-en/scenarios/checkin_return/no_symptoms_more_with_error.yml
@@ -13,7 +13,9 @@
 - user: deny
   bot: checkin_return/ask_mild_symptoms
 - user: deny
-  bot: checkin_return/ask_when_last_symptoms
+  bot: checkin_return/ask_when_first_symptoms
+- user: navigate_tests
+  bot: checkin_return/ask_when_first_symptoms_error
 - user: more
   bot: checkin_return/ask_anything_else_no_symptoms_more
 - user: done

--- a/integration-tests-en/scenarios/daily_ci/feel_better_mild_symptoms_with_error.yml
+++ b/integration-tests-en/scenarios/daily_ci/feel_better_mild_symptoms_with_error.yml
@@ -2,6 +2,8 @@
   bot: daily_ci/greet_profile_1
 - user: daily_ci/continue
   bot: daily_ci/ask_feel
+- user: ask_question
+  bot: daily_ci/ask_feel_error
 - user: daily_ci/better
   bot: daily_ci/feel_better/ask_fever
 - user: deny

--- a/integration-tests-en/scenarios/daily_ci/feel_no_change_moderate_symptoms_with_error.yml
+++ b/integration-tests-en/scenarios/daily_ci/feel_no_change_moderate_symptoms_with_error.yml
@@ -2,6 +2,8 @@
   bot: daily_ci/greet_profile_2
 - user: daily_ci/continue
   bot: daily_ci/ask_feel
+- user: invalid_input
+  bot: daily_ci/ask_feel_error
 - user: daily_ci/no_change
   bot: daily_ci/feel_no_change/ask_fever
 - user: affirm

--- a/integration-tests-en/scenarios/daily_ci/feel_worse_moderate_symptoms_with_error.yml
+++ b/integration-tests-en/scenarios/daily_ci/feel_worse_moderate_symptoms_with_error.yml
@@ -2,6 +2,8 @@
   bot: daily_ci/greet_profile_2
 - user: daily_ci/continue
   bot: daily_ci/ask_feel
+- user: get_assessment
+  bot: daily_ci/ask_feel_error
 - user: daily_ci/worse
   bot: daily_ci/ask_symptoms_severe
 - user: deny

--- a/integration-tests-en/scenarios/tested_positive/no_symptoms_less_with_error.yml
+++ b/integration-tests-en/scenarios/tested_positive/no_symptoms_less_with_error.yml
@@ -16,7 +16,9 @@
   bot: tested_positive/ask_mild_symptoms
 - user: deny
   bot: tested_positive/ask_when_tested
-- user: less
+- user: get_assessment
+  bot: tested_positive/ask_when_tested_error
+- user: deny
   bot: tested_positive/ask_daily_ci_enrollment_no_symptoms_less
 - user: deny
   bot: tested_positive/ask_anything_else

--- a/integration-tests-en/scenarios/tested_positive/no_symptoms_more.yml
+++ b/integration-tests-en/scenarios/tested_positive/no_symptoms_more.yml
@@ -16,7 +16,7 @@
   bot: tested_positive/ask_mild_symptoms
 - user: deny
   bot: tested_positive/ask_when_tested
-- user: more
+- user: affirm
   bot: tested_positive/ask_anything_else_maybe_recovered
 - user: done
   bot: thank_you_take_care


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
Used the `unsupported intent` policy for remaining questions. As instructed, changed the intents in more/less than 14 days questions for affirm/deny. 

Added some examples of fallback in stories, and different examples (to avoid memoization policy) in integration tests. 

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->

does part of #350 

## Related changes

<!-- What other PRs does this PR depend on? -->
<!-- Please put references to other PRs here: -->
<!-- * #{pr-number}  -->

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [X] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
