### PR TITLE
chore: create additional hosts in dev

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -16,12 +16,10 @@
         timeoutSeconds: 30
       readiness:
         initialDelaySeconds: 60
-  ingressDev: &ingressDev
-    public:
-      ingress:
-        paths:
-          - /socket.io
-          - /webhooks/rest/webhook
+  ingressPaths: &ingressPaths
+    paths:
+      - /socket.io
+      - /webhooks/rest/webhook
 
 engine: ~2
 name: covidflow
@@ -62,19 +60,29 @@ environments:
       TWILIO_NUMBER: "+14382996778"
     components:
       core-en:
-        <<: *ingressDev
+        public:
+          ingress:
+            <<: *ingressPaths
+          additionalHostnames:
+            - covidflow-core-en.dev.dialogue.co
       core-fr:
-        <<: *ingressDev
+        public:
+          ingress:
+            <<: *ingressPaths
+          additionalHostnames:
+            - covidflow-core-fr.dev.dialogue.co
   prod-ca:
     components:
       core-en:
         public:
           ingress:
+            <<: *ingressPaths
             additionalHostnames:
               - covidflow-core-en.dialogue.co
       core-fr:
         public:
           ingress:
+            <<: *ingressPaths
             additionalHostnames:
               - covidflow-core-fr.dialogue.co
     environment:


### PR DESCRIPTION
## Description

<!-- Short summary of your changes. -->
<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
<!-- You can also leave notes for code reviewers here. -->
This will fix CORS issue in dev with socket.io. This will allow the ingress to accept those new hosts and create the appropriate certificate. The hosts themselves will not be created in route 53 for now as our kubernetes clusters only support dialoguecorp.com domain

## Related issues

<!-- Pull requests should be related to open GitHub Issues. -->
<!-- Please put all related issue IDs here: -->
<!-- * #{issue-number} -->
DIA-30691

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
